### PR TITLE
Add additional current status messages

### DIFF
--- a/TandemKit/Common/Dates.swift
+++ b/TandemKit/Common/Dates.swift
@@ -1,0 +1,33 @@
+//
+//  Dates.swift
+//  TandemKit
+//
+//  Created by OpenAI's Codex.
+//
+//  Swift port of pumpX2 Dates helper:
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/helpers/Dates.java
+//
+
+import Foundation
+
+struct Dates {
+    static let JANUARY_1_2008_UNIX_EPOCH: TimeInterval = 1199145600
+
+    static func fromJan12008ToUnixEpochSeconds(_ seconds: TimeInterval) -> TimeInterval {
+        return seconds + JANUARY_1_2008_UNIX_EPOCH
+    }
+
+    static func fromJan12008EpochSecondsToDate(_ seconds: TimeInterval) -> Date {
+        return Date(timeIntervalSince1970: fromJan12008ToUnixEpochSeconds(seconds))
+    }
+
+    static func fromInstantToJan12008EpochSeconds(_ date: Date) -> TimeInterval {
+        return date.timeIntervalSince1970 - JANUARY_1_2008_UNIX_EPOCH
+    }
+
+    private static let SECONDS_IN_DAY: TimeInterval = 60 * 60 * 24
+
+    static func fromJan12008EpochDaysToDate(_ days: TimeInterval) -> Date {
+        return Date(timeIntervalSince1970: fromJan12008ToUnixEpochSeconds(days * SECONDS_IN_DAY))
+    }
+}

--- a/TandemKit/Messages/CurrentStatus/BasalLimitSettings.swift
+++ b/TandemKit/Messages/CurrentStatus/BasalLimitSettings.swift
@@ -1,0 +1,61 @@
+//
+//  BasalLimitSettings.swift
+//  TandemKit
+//
+//  Created by OpenAI's Codex.
+//
+//  Swift representation of BasalLimitSettingsRequest and BasalLimitSettingsResponse based on
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/request/currentStatus/BasalLimitSettingsRequest.java
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/BasalLimitSettingsResponse.java
+//
+
+import Foundation
+
+/// Request basal limit settings from the pump.
+public class BasalLimitSettingsRequest: Message {
+    public static var props = MessageProps(
+        opCode: UInt8(bitPattern: Int8(-118)),
+        size: 0,
+        type: .Request,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+    }
+
+    public init() {
+        self.cargo = Data()
+    }
+}
+
+/// Response containing the configured basal limits.
+public class BasalLimitSettingsResponse: Message {
+    public static var props = MessageProps(
+        opCode: UInt8(bitPattern: Int8(-117)),
+        size: 8,
+        type: .Response,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+    public var basalLimit: UInt32
+    public var basalLimitDefault: UInt32
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+        self.basalLimit = Bytes.readUint32(cargo, 0)
+        self.basalLimitDefault = Bytes.readUint32(cargo, 4)
+    }
+
+    public init(basalLimit: UInt32, basalLimitDefault: UInt32) {
+        self.cargo = Bytes.combine(
+            Bytes.toUint32(basalLimit),
+            Bytes.toUint32(basalLimitDefault)
+        )
+        self.basalLimit = basalLimit
+        self.basalLimitDefault = basalLimitDefault
+    }
+}

--- a/TandemKit/Messages/CurrentStatus/CurrentBolusStatus.swift
+++ b/TandemKit/Messages/CurrentStatus/CurrentBolusStatus.swift
@@ -1,0 +1,105 @@
+//
+//  CurrentBolusStatus.swift
+//  TandemKit
+//
+//  Created by OpenAI's Codex.
+//
+//  Swift representation of CurrentBolusStatusRequest and CurrentBolusStatusResponse based on
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/request/currentStatus/CurrentBolusStatusRequest.java
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/CurrentBolusStatusResponse.java
+//
+
+import Foundation
+
+/// Request information about any currently delivering bolus.
+public class CurrentBolusStatusRequest: Message {
+    public static var props = MessageProps(
+        opCode: 44,
+        size: 0,
+        type: .Request,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+    }
+
+    public init() {
+        self.cargo = Data()
+    }
+}
+
+/// Response describing the currently active bolus, if any.
+public class CurrentBolusStatusResponse: Message {
+    public static var props = MessageProps(
+        opCode: 45,
+        size: 15,
+        type: .Response,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+    public var statusId: Int
+    public var bolusId: Int
+    public var timestamp: UInt32
+    public var requestedVolume: UInt32
+    public var bolusSourceId: Int
+    public var bolusTypeBitmask: Int
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+        self.statusId = Int(cargo[0])
+        self.bolusId = Bytes.readShort(cargo, 1)
+        self.timestamp = Bytes.readUint32(cargo, 5)
+        self.requestedVolume = Bytes.readUint32(cargo, 9)
+        self.bolusSourceId = Int(cargo[13])
+        self.bolusTypeBitmask = Int(cargo[14])
+    }
+
+    public init(statusId: Int, bolusId: Int, timestamp: UInt32, requestedVolume: UInt32, bolusSourceId: Int, bolusTypeBitmask: Int) {
+        self.cargo = Bytes.combine(
+            Bytes.firstByteLittleEndian(statusId),
+            Bytes.firstTwoBytesLittleEndian(bolusId),
+            Data([0,0]),
+            Bytes.toUint32(timestamp),
+            Bytes.toUint32(requestedVolume),
+            Bytes.firstByteLittleEndian(bolusSourceId),
+            Bytes.firstByteLittleEndian(bolusTypeBitmask)
+        )
+        self.statusId = statusId
+        self.bolusId = bolusId
+        self.timestamp = timestamp
+        self.requestedVolume = requestedVolume
+        self.bolusSourceId = bolusSourceId
+        self.bolusTypeBitmask = bolusTypeBitmask
+    }
+
+    public var status: CurrentBolusStatus? {
+        return CurrentBolusStatus(rawValue: statusId)
+    }
+
+    public var bolusSource: BolusSource? {
+        return BolusSource.fromId(bolusSourceId)
+    }
+
+    public var bolusTypes: Set<BolusType> {
+        return BolusType.fromBitmask(bolusTypeBitmask)
+    }
+
+    public var timestampDate: Date {
+        return Dates.fromJan12008EpochSecondsToDate(TimeInterval(timestamp))
+    }
+
+    /// Whether the data is valid (the bolus is still current).
+    public var isValid: Bool {
+        return !(status == .alreadyDeliveredOrInvalid && bolusId == 0 && timestamp == 0)
+    }
+
+    public enum CurrentBolusStatus: Int {
+        case requesting = 2
+        case delivering = 1
+        case alreadyDeliveredOrInvalid = 0
+    }
+}

--- a/TandemKit/Messages/CurrentStatus/LastBG.swift
+++ b/TandemKit/Messages/CurrentStatus/LastBG.swift
@@ -1,0 +1,78 @@
+//
+//  LastBG.swift
+//  TandemKit
+//
+//  Created by OpenAI's Codex.
+//
+//  Swift representation of LastBGRequest and LastBGResponse based on
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/request/currentStatus/LastBGRequest.java
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/LastBGResponse.java
+//
+
+import Foundation
+
+/// Request the last BG entered via the Bolus Calculator.
+public class LastBGRequest: Message {
+    public static var props = MessageProps(
+        opCode: 50,
+        size: 0,
+        type: .Request,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+    }
+
+    public init() {
+        self.cargo = Data()
+    }
+}
+
+/// Response containing the last manually entered BG.
+public class LastBGResponse: Message {
+    public static var props = MessageProps(
+        opCode: 51,
+        size: 7,
+        type: .Response,
+        characteristic: .CURRENT_STATUS_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+    public var bgTimestamp: UInt32
+    public var bgValue: Int
+    public var bgSourceId: Int
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+        self.bgTimestamp = Bytes.readUint32(cargo, 0)
+        self.bgValue = Bytes.readShort(cargo, 4)
+        self.bgSourceId = Int(cargo[6])
+    }
+
+    public init(bgTimestamp: UInt32, bgValue: Int, bgSourceId: Int) {
+        self.cargo = Bytes.combine(
+            Bytes.toUint32(bgTimestamp),
+            Bytes.firstTwoBytesLittleEndian(bgValue),
+            Bytes.firstByteLittleEndian(bgSourceId)
+        )
+        self.bgTimestamp = bgTimestamp
+        self.bgValue = bgValue
+        self.bgSourceId = bgSourceId
+    }
+
+    public var bgSource: BgSource? {
+        return BgSource(rawValue: bgSourceId)
+    }
+
+    public var bgTimestampDate: Date {
+        return Dates.fromJan12008EpochSecondsToDate(TimeInterval(bgTimestamp))
+    }
+
+    public enum BgSource: Int {
+        case manual = 0
+        case cgm = 1
+    }
+}

--- a/TandemKit/Messages/Models/BolusDelivery.swift
+++ b/TandemKit/Messages/Models/BolusDelivery.swift
@@ -1,0 +1,47 @@
+//
+//  BolusDelivery.swift
+//  TandemKit
+//
+//  Created by OpenAI's Codex.
+//
+//  Swift representation of enums from BolusDeliveryHistoryLog
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
+//
+
+import Foundation
+
+public enum BolusSource: Int {
+    case quickBolus = 0
+    case gui = 1
+    case controlIQAutoBolus = 7
+    case bluetoothRemoteBolus = 8
+
+    public static func fromId(_ id: Int) -> BolusSource? {
+        return BolusSource(rawValue: id)
+    }
+}
+
+public enum BolusType: Int, CaseIterable {
+    case food1 = 1
+    case correction = 2
+    case extended = 4
+    case food2 = 8
+
+    public static func fromBitmask(_ bitmask: Int) -> Set<BolusType> {
+        var ret = Set<BolusType>()
+        for t in BolusType.allCases {
+            if (bitmask & t.rawValue) != 0 {
+                ret.insert(t)
+            }
+        }
+        return ret
+    }
+
+    public static func toBitmask(_ types: [BolusType]) -> Int {
+        var bitmask = 0
+        for t in types {
+            bitmask |= t.rawValue
+        }
+        return bitmask
+    }
+}


### PR DESCRIPTION
## Summary
- add helper `Dates` for epoch conversions
- add basal limit settings request and response
- add current bolus status request and response
- add last BG request and response
- add BolusDelivery enums used by bolus responses

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687864e67ab8832c899cab19a42fd573