### PR TITLE
Add Carthage build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.0'
+          xcode-version: '16.2.0'
       - name: Install Carthage
         run: brew install carthage
       - name: Bootstrap Carthage dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.0'
       - name: Install Carthage
         run: brew install carthage
       - name: Bootstrap Carthage dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Carthage
+        run: brew install carthage
+      - name: Bootstrap Carthage dependencies
+        run: ./carthage.sh bootstrap --platform iOS --no-use-binaries
+      - name: Build TandemKit
+        run: xcodebuild -project TandemKit.xcodeproj -scheme TandemKit -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Install Carthage
         run: brew install carthage
       - name: Bootstrap Carthage dependencies
-        run: ./carthage.sh bootstrap --platform iOS --no-use-binaries
+        run: ./carthage.sh bootstrap --platform iOS --no-use-binaries --use-xcframeworks
       - name: Build TandemKit
         run: xcodebuild -project TandemKit.xcodeproj -scheme TandemKit -destination 'generic/platform=iOS' -configuration Release CODE_SIGNING_ALLOWED=NO build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project relies on Carthage for several dependencies (LoopKit, LoopKitUI, Lo
 2. Run the following command from the repository root:
    
    ```bash
-   ./carthage.sh update --platform iOS
+   ./carthage.sh update --platform iOS --use-xcframeworks
    ```
 
    This script mirrors the one used by OmniBLE and ensures the correct build settings for modern Xcode versions.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# TandemKit
+
+TandemKit is a Swift library that provides communication utilities for Tandem insulin pumps.
+
+## Building
+
+This project relies on Carthage for several dependencies (LoopKit, LoopKitUI, LoopTestingKit, MockKit, and MockKitUI). The binary frameworks are not committed to the repository. Before building the Xcode project you must fetch and build these frameworks.
+
+1. Install [Carthage](https://github.com/Carthage/Carthage).
+2. Run the following command from the repository root:
+   
+   ```bash
+   ./carthage.sh update --platform iOS
+   ```
+
+   This script mirrors the one used by OmniBLE and ensures the correct build settings for modern Xcode versions.
+3. After Carthage finishes building, open `TandemKit.xcodeproj` and build the targets.
+
+The generated frameworks will appear under `Carthage/Build/` and are referenced by the project via a `carthage copy-frameworks` build phase.

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 and later make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+CURRENT_XCODE_VERSION="$(xcodebuild -version | grep "Xcode" | cut -d' ' -f2 | cut -d'.' -f1)00"
+CURRENT_XCODE_BUILD=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_${CURRENT_XCODE_VERSION}__BUILD_${CURRENT_XCODE_BUILD} = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_'${CURRENT_XCODE_VERSION}' = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_$(XCODE_VERSION_MAJOR)__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
## Summary
- add `carthage.sh` script modeled after OmniBLE
- document building with Carthage in a new README
- configure GitHub Actions to build the library

## Testing
- `swift --version`
- `./carthage.sh bootstrap --platform iOS --no-use-binaries` *(fails: `xcodebuild: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b1dd6ea8c832c89e055a8d44f54e5