### PR TITLE
Add JPAKE session scaffolding

### DIFF
--- a/Sources/TandemKit/PumpManager/PumpCommSession.swift
+++ b/Sources/TandemKit/PumpManager/PumpCommSession.swift
@@ -1,0 +1,45 @@
+#if canImport(HealthKit)
+import Foundation
+import TandemCore
+
+protocol PumpCommSessionDelegate: AnyObject {
+    func pumpCommSession(_ pumpCommSession: PumpCommSession, didChange state: PumpState)
+}
+
+public class PumpCommSession {
+    private let sessionQueue = DispatchQueue(label: "com.jwoglom.TandemKit.PumpCommSession.queue")
+    private(set) var state: PumpState
+    weak var delegate: PumpCommSessionDelegate?
+
+    public init(pumpState: PumpState, delegate: PumpCommSessionDelegate? = nil) {
+        self.state = pumpState
+        self.delegate = delegate
+    }
+
+    public func runSession(withName name: String, _ block: @escaping @Sendable () -> Void) {
+        sessionQueue.async(execute: block)
+    }
+
+    public func assertOnSessionQueue() {
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+    }
+
+    #if canImport(SwiftECC) && canImport(BigInt) && canImport(CryptoKit)
+    public func pair(transport: PumpMessageTransport, pairingCode: String) throws {
+        assertOnSessionQueue()
+        let builder = JpakeAuthBuilder.initializeWithPairingCode(pairingCode)
+        while !builder.done() && !builder.invalid() {
+            guard let request = builder.nextRequest() else { break }
+            let response = try transport.sendMessage(request)
+            builder.processResponse(response)
+        }
+        guard builder.done(), let secret = builder.getDerivedSecret() else {
+            throw PumpCommError.missingAuthenticationKey
+        }
+        state.derivedSecret = secret
+        state.serverNonce = builder.getServerNonce()
+        delegate?.pumpCommSession(self, didChange: state)
+    }
+    #endif
+}
+#endif

--- a/Sources/TandemKit/PumpManager/PumpMessageTransport.swift
+++ b/Sources/TandemKit/PumpManager/PumpMessageTransport.swift
@@ -1,0 +1,8 @@
+#if canImport(HealthKit)
+import Foundation
+import TandemCore
+
+public protocol PumpMessageTransport {
+    func sendMessage(_ message: Message) throws -> Message
+}
+#endif

--- a/Sources/TandemKit/PumpManager/PumpState.swift
+++ b/Sources/TandemKit/PumpManager/PumpState.swift
@@ -5,36 +5,49 @@
 //  Created by James Woglom on 1/5/25.
 //
 
+import Foundation
+
 public struct PumpState: RawRepresentable, Equatable, CustomDebugStringConvertible {
     
     public typealias RawValue = [String: Any]
     
     public let address: UInt32
-    
-    public init(address: UInt32) {
+    public var derivedSecret: Data?
+    public var serverNonce: Data?
+
+    public init(address: UInt32, derivedSecret: Data? = nil, serverNonce: Data? = nil) {
         self.address = address
+        self.derivedSecret = derivedSecret
+        self.serverNonce = serverNonce
     }
     
     public init?(rawValue: RawValue) {
         
         guard let address = rawValue["address"] as? UInt32
         else { return nil }
-        
+
         self.address = address
+        self.derivedSecret = rawValue["derivedSecret"] as? Data
+        self.serverNonce = rawValue["serverNonce"] as? Data
     }
     
     public var rawValue: RawValue {
         var rawValue: RawValue = [
             "address": address,
         ]
-        
+
+        rawValue["derivedSecret"] = derivedSecret
+        rawValue["serverNonce"] = serverNonce
+
         return rawValue
     }
     
     public var debugDescription: String {
         return [
             "### PumpState",
-            "* address: \(String(format: "%04X", address))"
+            "* address: \(String(format: "%04X", address))",
+            "* hasDerivedSecret: \(derivedSecret != nil)",
+            "* hasServerNonce: \(serverNonce != nil)"
         ].joined(separator: "\n")
     }
 }


### PR DESCRIPTION
## Summary
- expand `PumpState` to track derived secrets and session nonce
- introduce `PumpCommSession` and `PumpMessageTransport` abstractions
- implement basic JPAKE pairing flow in `PumpComm`

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b13135d650832c9f7b0cad13af5b20