### PR TITLE
docs: track transferred message tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,245 +2,461 @@
 
 ### Authentication
 Requests:
-- [ ] AbstractCentralChallengeRequest
-- [ ] CentralChallengeRequest
-- [ ] Jpake1aRequest
-- [ ] Jpake1bRequest
-- [ ] Jpake2Request
-- [ ] Jpake3SessionKeyRequest
-- [ ] Jpake4KeyConfirmationRequest
-- [ ] PumpChallengeRequest
+- [x] AbstractCentralChallengeRequest
+   - [ ] Tests for AbstractCentralChallengeRequest
+- [x] CentralChallengeRequest
+   - [ ] Tests for CentralChallengeRequest
+- [x] Jpake1aRequest
+   - [x] Tests for Jpake1aRequest
+- [x] Jpake1bRequest
+   - [ ] Tests for Jpake1bRequest
+- [x] Jpake2Request
+   - [ ] Tests for Jpake2Request
+- [x] Jpake3SessionKeyRequest
+   - [ ] Tests for Jpake3SessionKeyRequest
+- [x] Jpake4KeyConfirmationRequest
+   - [ ] Tests for Jpake4KeyConfirmationRequest
+- [x] PumpChallengeRequest
+   - [ ] Tests for PumpChallengeRequest
 
 Responses:
-- [ ] AbstractCentralChallengeResponse
+- [x] AbstractCentralChallengeResponse
+   - [ ] Tests for AbstractCentralChallengeResponse
 - [ ] AbstractPumpChallengeResponse
-- [ ] CentralChallengeResponse
-- [ ] Jpake1aResponse
-- [ ] Jpake1bResponse
-- [ ] Jpake2Response
-- [ ] Jpake3SessionKeyResponse
-- [ ] Jpake4KeyConfirmationResponse
-- [ ] PumpChallengeResponse
+- [x] CentralChallengeResponse
+   - [ ] Tests for CentralChallengeResponse
+- [x] Jpake1aResponse
+   - [ ] Tests for Jpake1aResponse
+- [x] Jpake1bResponse
+   - [ ] Tests for Jpake1bResponse
+- [x] Jpake2Response
+   - [ ] Tests for Jpake2Response
+- [x] Jpake3SessionKeyResponse
+   - [ ] Tests for Jpake3SessionKeyResponse
+- [x] Jpake4KeyConfirmationResponse
+   - [ ] Tests for Jpake4KeyConfirmationResponse
+- [x] PumpChallengeResponse
+   - [ ] Tests for PumpChallengeResponse
 
 ### Control
 Requests:
 - [x] BolusPermissionReleaseRequest
-- [ ] BolusPermissionRequest
-- [ ] CancelBolusRequest
-- [ ] ChangeControlIQSettingsRequest
-- [ ] ChangeTimeDateRequest
-- [ ] CreateIDPRequest
-- [ ] DeleteIDPRequest
-- [ ] DisconnectPumpRequest
-- [ ] DismissNotificationRequest
-- [ ] EnterChangeCartridgeModeRequest
-- [ ] EnterFillTubingModeRequest
-- [ ] ExitChangeCartridgeModeRequest
-- [ ] ExitFillTubingModeRequest
-- [ ] FillCannulaRequest
-- [ ] InitiateBolusRequest
-- [ ] PlaySoundRequest
-- [ ] RemoteBgEntryRequest
-- [ ] RemoteCarbEntryRequest
-- [ ] RenameIDPRequest
-- [ ] ResumePumpingRequest
-- [ ] SetActiveIDPRequest
-- [ ] SetDexcomG7PairingCodeRequest
-- [ ] SetG6TransmitterIdRequest
-- [ ] SetIDPSegmentRequest
-- [ ] SetIDPSettingsRequest
-- [ ] SetMaxBasalLimitRequest
-- [ ] SetMaxBolusLimitRequest
-- [ ] SetModesRequest
-- [ ] SetQuickBolusSettingsRequest
-- [ ] SetSleepScheduleRequest
-- [ ] SetTempRateRequest
-- [ ] StartDexcomG6SensorSessionRequest
-- [ ] StopDexcomCGMSensorSessionRequest
-- [ ] StopTempRateRequest
-- [ ] SuspendPumpingRequest
+   - [x] Tests for BolusPermissionReleaseRequest
+- [x] BolusPermissionRequest
+   - [ ] Tests for BolusPermissionRequest
+- [x] CancelBolusRequest
+   - [ ] Tests for CancelBolusRequest
+- [x] ChangeControlIQSettingsRequest
+   - [ ] Tests for ChangeControlIQSettingsRequest
+- [x] ChangeTimeDateRequest
+   - [ ] Tests for ChangeTimeDateRequest
+- [x] CreateIDPRequest
+   - [ ] Tests for CreateIDPRequest
+- [x] DeleteIDPRequest
+   - [ ] Tests for DeleteIDPRequest
+- [x] DisconnectPumpRequest
+   - [ ] Tests for DisconnectPumpRequest
+- [x] DismissNotificationRequest
+   - [ ] Tests for DismissNotificationRequest
+- [x] EnterChangeCartridgeModeRequest
+   - [ ] Tests for EnterChangeCartridgeModeRequest
+- [x] EnterFillTubingModeRequest
+   - [ ] Tests for EnterFillTubingModeRequest
+- [x] ExitChangeCartridgeModeRequest
+   - [ ] Tests for ExitChangeCartridgeModeRequest
+- [x] ExitFillTubingModeRequest
+   - [ ] Tests for ExitFillTubingModeRequest
+- [x] FillCannulaRequest
+   - [ ] Tests for FillCannulaRequest
+- [x] InitiateBolusRequest
+   - [ ] Tests for InitiateBolusRequest
+- [x] PlaySoundRequest
+   - [ ] Tests for PlaySoundRequest
+- [x] RemoteBgEntryRequest
+   - [ ] Tests for RemoteBgEntryRequest
+- [x] RemoteCarbEntryRequest
+   - [ ] Tests for RemoteCarbEntryRequest
+- [x] RenameIDPRequest
+   - [ ] Tests for RenameIDPRequest
+- [x] ResumePumpingRequest
+   - [ ] Tests for ResumePumpingRequest
+- [x] SetActiveIDPRequest
+   - [ ] Tests for SetActiveIDPRequest
+- [x] SetDexcomG7PairingCodeRequest
+   - [ ] Tests for SetDexcomG7PairingCodeRequest
+- [x] SetG6TransmitterIdRequest
+   - [ ] Tests for SetG6TransmitterIdRequest
+- [x] SetIDPSegmentRequest
+   - [ ] Tests for SetIDPSegmentRequest
+- [x] SetIDPSettingsRequest
+   - [ ] Tests for SetIDPSettingsRequest
+- [x] SetMaxBasalLimitRequest
+   - [ ] Tests for SetMaxBasalLimitRequest
+- [x] SetMaxBolusLimitRequest
+   - [ ] Tests for SetMaxBolusLimitRequest
+- [x] SetModesRequest
+   - [ ] Tests for SetModesRequest
+- [x] SetQuickBolusSettingsRequest
+   - [ ] Tests for SetQuickBolusSettingsRequest
+- [x] SetSleepScheduleRequest
+   - [ ] Tests for SetSleepScheduleRequest
+- [x] SetTempRateRequest
+   - [ ] Tests for SetTempRateRequest
+- [x] StartDexcomG6SensorSessionRequest
+   - [ ] Tests for StartDexcomG6SensorSessionRequest
+- [x] StopDexcomCGMSensorSessionRequest
+   - [ ] Tests for StopDexcomCGMSensorSessionRequest
+- [x] StopTempRateRequest
+   - [ ] Tests for StopTempRateRequest
+- [x] SuspendPumpingRequest
+   - [ ] Tests for SuspendPumpingRequest
 
 Responses:
 - [x] BolusPermissionReleaseResponse
-- [ ] BolusPermissionResponse
-- [ ] CancelBolusResponse
-- [ ] ChangeControlIQSettingsResponse
-- [ ] ChangeTimeDateResponse
-- [ ] CreateIDPResponse
-- [ ] DeleteIDPResponse
-- [ ] DisconnectPumpResponse
-- [ ] DismissNotificationResponse
-- [ ] EnterChangeCartridgeModeResponse
-- [ ] EnterFillTubingModeResponse
-- [ ] ExitChangeCartridgeModeResponse
-- [ ] ExitFillTubingModeResponse
-- [ ] FillCannulaResponse
-- [ ] InitiateBolusResponse
-- [ ] PlaySoundResponse
-- [ ] RemoteBgEntryResponse
-- [ ] RemoteCarbEntryResponse
-- [ ] RenameIDPResponse
-- [ ] ResumePumpingResponse
-- [ ] SetActiveIDPResponse
-- [ ] SetDexcomG7PairingCodeResponse
-- [ ] SetG6TransmitterIdResponse
-- [ ] SetIDPSegmentResponse
-- [ ] SetIDPSettingsResponse
-- [ ] SetMaxBasalLimitResponse
-- [ ] SetMaxBolusLimitResponse
-- [ ] SetModesResponse
-- [ ] SetQuickBolusSettingsResponse
-- [ ] SetSleepScheduleResponse
-- [ ] SetTempRateResponse
-- [ ] StartDexcomG6SensorSessionResponse
-- [ ] StopDexcomCGMSensorSessionResponse
-- [ ] StopTempRateResponse
-- [ ] SuspendPumpingResponse
+   - [x] Tests for BolusPermissionReleaseResponse
+- [x] BolusPermissionResponse
+   - [ ] Tests for BolusPermissionResponse
+- [x] CancelBolusResponse
+   - [ ] Tests for CancelBolusResponse
+- [x] ChangeControlIQSettingsResponse
+   - [ ] Tests for ChangeControlIQSettingsResponse
+- [x] ChangeTimeDateResponse
+   - [ ] Tests for ChangeTimeDateResponse
+- [x] CreateIDPResponse
+   - [ ] Tests for CreateIDPResponse
+- [x] DeleteIDPResponse
+   - [ ] Tests for DeleteIDPResponse
+- [x] DisconnectPumpResponse
+   - [ ] Tests for DisconnectPumpResponse
+- [x] DismissNotificationResponse
+   - [ ] Tests for DismissNotificationResponse
+- [x] EnterChangeCartridgeModeResponse
+   - [ ] Tests for EnterChangeCartridgeModeResponse
+- [x] EnterFillTubingModeResponse
+   - [ ] Tests for EnterFillTubingModeResponse
+- [x] ExitChangeCartridgeModeResponse
+   - [ ] Tests for ExitChangeCartridgeModeResponse
+- [x] ExitFillTubingModeResponse
+   - [ ] Tests for ExitFillTubingModeResponse
+- [x] FillCannulaResponse
+   - [ ] Tests for FillCannulaResponse
+- [x] InitiateBolusResponse
+   - [ ] Tests for InitiateBolusResponse
+- [x] PlaySoundResponse
+   - [ ] Tests for PlaySoundResponse
+- [x] RemoteBgEntryResponse
+   - [ ] Tests for RemoteBgEntryResponse
+- [x] RemoteCarbEntryResponse
+   - [ ] Tests for RemoteCarbEntryResponse
+- [x] RenameIDPResponse
+   - [ ] Tests for RenameIDPResponse
+- [x] ResumePumpingResponse
+   - [ ] Tests for ResumePumpingResponse
+- [x] SetActiveIDPResponse
+   - [ ] Tests for SetActiveIDPResponse
+- [x] SetDexcomG7PairingCodeResponse
+   - [ ] Tests for SetDexcomG7PairingCodeResponse
+- [x] SetG6TransmitterIdResponse
+   - [ ] Tests for SetG6TransmitterIdResponse
+- [x] SetIDPSegmentResponse
+   - [ ] Tests for SetIDPSegmentResponse
+- [x] SetIDPSettingsResponse
+   - [ ] Tests for SetIDPSettingsResponse
+- [x] SetMaxBasalLimitResponse
+   - [ ] Tests for SetMaxBasalLimitResponse
+- [x] SetMaxBolusLimitResponse
+   - [ ] Tests for SetMaxBolusLimitResponse
+- [x] SetModesResponse
+   - [ ] Tests for SetModesResponse
+- [x] SetQuickBolusSettingsResponse
+   - [ ] Tests for SetQuickBolusSettingsResponse
+- [x] SetSleepScheduleResponse
+   - [ ] Tests for SetSleepScheduleResponse
+- [x] SetTempRateResponse
+   - [ ] Tests for SetTempRateResponse
+- [x] StartDexcomG6SensorSessionResponse
+   - [ ] Tests for StartDexcomG6SensorSessionResponse
+- [x] StopDexcomCGMSensorSessionResponse
+   - [ ] Tests for StopDexcomCGMSensorSessionResponse
+- [x] StopTempRateResponse
+   - [ ] Tests for StopTempRateResponse
+- [x] SuspendPumpingResponse
+   - [ ] Tests for SuspendPumpingResponse
 
 ### ControlStream
 Requests:
-- [ ] NonexistentDetectingCartridgeStateStreamRequest
-- [ ] NonexistentEnterChangeCartridgeModeStateStreamRequest
-- [ ] NonexistentExitFillTubingModeStateStreamRequest
-- [ ] NonexistentFillCannulaStateStreamRequest
-- [ ] NonexistentFillTubingStateStreamRequest
+- [x] NonexistentDetectingCartridgeStateStreamRequest
+   - [ ] Tests for NonexistentDetectingCartridgeStateStreamRequest
+- [x] NonexistentEnterChangeCartridgeModeStateStreamRequest
+   - [ ] Tests for NonexistentEnterChangeCartridgeModeStateStreamRequest
+- [x] NonexistentExitFillTubingModeStateStreamRequest
+   - [ ] Tests for NonexistentExitFillTubingModeStateStreamRequest
+- [x] NonexistentFillCannulaStateStreamRequest
+   - [ ] Tests for NonexistentFillCannulaStateStreamRequest
+- [x] NonexistentFillTubingStateStreamRequest
+   - [ ] Tests for NonexistentFillTubingStateStreamRequest
 - [ ] NonexistentPumpingStateStreamRequest
 
 Responses:
 - [ ] ControlStreamMessages
-- [ ] DetectingCartridgeStateStreamResponse
-- [ ] EnterChangeCartridgeModeStateStreamResponse
-- [ ] ExitFillTubingModeStateStreamResponse
-- [ ] FillCannulaStateStreamResponse
-- [ ] FillTubingStateStreamResponse
+- [x] DetectingCartridgeStateStreamResponse
+   - [ ] Tests for DetectingCartridgeStateStreamResponse
+- [x] EnterChangeCartridgeModeStateStreamResponse
+   - [ ] Tests for EnterChangeCartridgeModeStateStreamResponse
+- [x] ExitFillTubingModeStateStreamResponse
+   - [ ] Tests for ExitFillTubingModeStateStreamResponse
+- [x] FillCannulaStateStreamResponse
+   - [ ] Tests for FillCannulaStateStreamResponse
+- [x] FillTubingStateStreamResponse
+   - [ ] Tests for FillTubingStateStreamResponse
 - [ ] PumpingStateStreamResponse
 
 ### CurrentStatus
 Requests:
-- [ ] AlarmStatusRequest
-- [ ] AlertStatusRequest
-- [ ] ApiVersionRequest
-- [ ] BasalIQAlertInfoRequest
-- [ ] BasalIQSettingsRequest
-- [ ] BasalIQStatusRequest
-- [ ] BasalLimitSettingsRequest
-- [ ] BolusCalcDataSnapshotRequest
-- [ ] BolusPermissionChangeReasonRequest
-- [ ] CGMAlertStatusRequest
-- [ ] CGMGlucoseAlertSettingsRequest
-- [ ] CGMHardwareInfoRequest
-- [ ] CGMOORAlertSettingsRequest
-- [ ] CGMRateAlertSettingsRequest
-- [ ] CGMStatusRequest
-- [ ] CommonSoftwareInfoRequest
-- [ ] ControlIQIOBRequest
-- [ ] ControlIQInfoV1Request
-- [ ] ControlIQInfoV2Request
-- [ ] ControlIQSleepScheduleRequest
-- [ ] CurrentBasalStatusRequest
-- [ ] CurrentBatteryV1Request
-- [ ] CurrentBatteryV2Request
-- [ ] CurrentBolusStatusRequest
-- [ ] CurrentEGVGuiDataRequest
-- [ ] ExtendedBolusStatusRequest
-- [ ] GetG6TransmitterHardwareInfoRequest
-- [ ] GetSavedG7PairingCodeRequest
-- [ ] GlobalMaxBolusSettingsRequest
-- [ ] HistoryLogRequest
-- [ ] HistoryLogStatusRequest
-- [ ] HomeScreenMirrorRequest
-- [ ] IDPSegmentRequest
-- [ ] IDPSettingsRequest
-- [ ] InsulinStatusRequest
-- [ ] LastBGRequest
-- [ ] LastBolusStatusRequest
-- [ ] LastBolusStatusV2Request
-- [ ] LocalizationRequest
-- [ ] MalfunctionStatusRequest
-- [ ] NonControlIQIOBRequest
-- [ ] OtherNotification2StatusRequest
-- [ ] OtherNotificationStatusRequest
-- [ ] ProfileStatusRequest
-- [ ] PumpFeaturesV1Request
-- [ ] PumpFeaturesV2Request
-- [ ] PumpGlobalsRequest
-- [ ] PumpSettingsRequest
-- [ ] PumpVersionRequest
-- [ ] ReminderStatusRequest
-- [ ] RemindersRequest
-- [ ] TempRateRequest
-- [ ] TimeSinceResetRequest
-- [ ] UnknownMobiOpcode110Request
-- [ ] UnknownMobiOpcode20Request
-- [ ] UnknownMobiOpcode30Request
-- [ ] UnknownMobiOpcodeNeg124Request
-- [ ] UnknownMobiOpcodeNeg66Request
-- [ ] UnknownMobiOpcodeNeg70Request
+- [x] AlarmStatusRequest
+   - [ ] Tests for AlarmStatusRequest
+- [x] AlertStatusRequest
+   - [ ] Tests for AlertStatusRequest
+- [x] ApiVersionRequest
+   - [x] Tests for ApiVersionRequest
+- [x] BasalIQAlertInfoRequest
+   - [ ] Tests for BasalIQAlertInfoRequest
+- [x] BasalIQSettingsRequest
+   - [ ] Tests for BasalIQSettingsRequest
+- [x] BasalIQStatusRequest
+   - [ ] Tests for BasalIQStatusRequest
+- [x] BasalLimitSettingsRequest
+   - [ ] Tests for BasalLimitSettingsRequest
+- [x] BolusCalcDataSnapshotRequest
+   - [ ] Tests for BolusCalcDataSnapshotRequest
+- [x] BolusPermissionChangeReasonRequest
+   - [ ] Tests for BolusPermissionChangeReasonRequest
+- [x] CGMAlertStatusRequest
+   - [ ] Tests for CGMAlertStatusRequest
+- [x] CGMGlucoseAlertSettingsRequest
+   - [ ] Tests for CGMGlucoseAlertSettingsRequest
+- [x] CGMHardwareInfoRequest
+   - [ ] Tests for CGMHardwareInfoRequest
+- [x] CGMOORAlertSettingsRequest
+   - [ ] Tests for CGMOORAlertSettingsRequest
+- [x] CGMRateAlertSettingsRequest
+   - [ ] Tests for CGMRateAlertSettingsRequest
+- [x] CGMStatusRequest
+   - [ ] Tests for CGMStatusRequest
+- [x] CommonSoftwareInfoRequest
+   - [ ] Tests for CommonSoftwareInfoRequest
+- [x] ControlIQIOBRequest
+   - [ ] Tests for ControlIQIOBRequest
+- [x] ControlIQInfoV1Request
+   - [ ] Tests for ControlIQInfoV1Request
+- [x] ControlIQInfoV2Request
+   - [ ] Tests for ControlIQInfoV2Request
+- [x] ControlIQSleepScheduleRequest
+   - [ ] Tests for ControlIQSleepScheduleRequest
+- [x] CurrentBasalStatusRequest
+   - [ ] Tests for CurrentBasalStatusRequest
+- [x] CurrentBatteryV1Request
+   - [ ] Tests for CurrentBatteryV1Request
+- [x] CurrentBatteryV2Request
+   - [ ] Tests for CurrentBatteryV2Request
+- [x] CurrentBolusStatusRequest
+   - [ ] Tests for CurrentBolusStatusRequest
+- [x] CurrentEGVGuiDataRequest
+   - [ ] Tests for CurrentEGVGuiDataRequest
+- [x] ExtendedBolusStatusRequest
+   - [ ] Tests for ExtendedBolusStatusRequest
+- [x] GetG6TransmitterHardwareInfoRequest
+   - [ ] Tests for GetG6TransmitterHardwareInfoRequest
+- [x] GetSavedG7PairingCodeRequest
+   - [ ] Tests for GetSavedG7PairingCodeRequest
+- [x] GlobalMaxBolusSettingsRequest
+   - [ ] Tests for GlobalMaxBolusSettingsRequest
+- [x] HistoryLogRequest
+   - [ ] Tests for HistoryLogRequest
+- [x] HistoryLogStatusRequest
+   - [ ] Tests for HistoryLogStatusRequest
+- [x] HomeScreenMirrorRequest
+   - [ ] Tests for HomeScreenMirrorRequest
+- [x] IDPSegmentRequest
+   - [ ] Tests for IDPSegmentRequest
+- [x] IDPSettingsRequest
+   - [ ] Tests for IDPSettingsRequest
+- [x] InsulinStatusRequest
+   - [ ] Tests for InsulinStatusRequest
+- [x] LastBGRequest
+   - [ ] Tests for LastBGRequest
+- [x] LastBolusStatusRequest
+   - [ ] Tests for LastBolusStatusRequest
+- [x] LastBolusStatusV2Request
+   - [ ] Tests for LastBolusStatusV2Request
+- [x] LocalizationRequest
+   - [ ] Tests for LocalizationRequest
+- [x] MalfunctionStatusRequest
+   - [ ] Tests for MalfunctionStatusRequest
+- [x] NonControlIQIOBRequest
+   - [ ] Tests for NonControlIQIOBRequest
+- [x] OtherNotification2StatusRequest
+   - [ ] Tests for OtherNotification2StatusRequest
+- [x] OtherNotificationStatusRequest
+   - [ ] Tests for OtherNotificationStatusRequest
+- [x] ProfileStatusRequest
+   - [ ] Tests for ProfileStatusRequest
+- [x] PumpFeaturesV1Request
+   - [ ] Tests for PumpFeaturesV1Request
+- [x] PumpFeaturesV2Request
+   - [ ] Tests for PumpFeaturesV2Request
+- [x] PumpGlobalsRequest
+   - [ ] Tests for PumpGlobalsRequest
+- [x] PumpSettingsRequest
+   - [ ] Tests for PumpSettingsRequest
+- [x] PumpVersionRequest
+   - [ ] Tests for PumpVersionRequest
+- [x] ReminderStatusRequest
+   - [ ] Tests for ReminderStatusRequest
+- [x] RemindersRequest
+   - [ ] Tests for RemindersRequest
+- [x] TempRateRequest
+   - [ ] Tests for TempRateRequest
+- [x] TimeSinceResetRequest
+   - [ ] Tests for TimeSinceResetRequest
+- [x] UnknownMobiOpcode110Request
+   - [ ] Tests for UnknownMobiOpcode110Request
+- [x] UnknownMobiOpcode20Request
+   - [ ] Tests for UnknownMobiOpcode20Request
+- [x] UnknownMobiOpcode30Request
+   - [ ] Tests for UnknownMobiOpcode30Request
+- [x] UnknownMobiOpcodeNeg124Request
+   - [ ] Tests for UnknownMobiOpcodeNeg124Request
+- [x] UnknownMobiOpcodeNeg66Request
+   - [ ] Tests for UnknownMobiOpcodeNeg66Request
+- [x] UnknownMobiOpcodeNeg70Request
+   - [ ] Tests for UnknownMobiOpcodeNeg70Request
 
 Responses:
-- [ ] AlarmStatusResponse
-- [ ] AlertStatusResponse
-- [ ] ApiVersionResponse
-- [ ] BasalIQAlertInfoResponse
-- [ ] BasalIQSettingsResponse
-- [ ] BasalIQStatusResponse
-- [ ] BasalLimitSettingsResponse
-- [ ] BolusCalcDataSnapshotResponse
-- [ ] BolusPermissionChangeReasonResponse
-- [ ] CGMAlertStatusResponse
-- [ ] CGMGlucoseAlertSettingsResponse
-- [ ] CGMHardwareInfoResponse
-- [ ] CGMOORAlertSettingsResponse
-- [ ] CGMRateAlertSettingsResponse
-- [ ] CGMStatusResponse
-- [ ] CommonSoftwareInfoResponse
-- [ ] ControlIQIOBResponse
-- [ ] ControlIQInfoAbstractResponse
-- [ ] ControlIQInfoV1Response
-- [ ] ControlIQInfoV2Response
-- [ ] ControlIQSleepScheduleResponse
-- [ ] CurrentBasalStatusResponse
+- [x] AlarmStatusResponse
+   - [ ] Tests for AlarmStatusResponse
+- [x] AlertStatusResponse
+   - [ ] Tests for AlertStatusResponse
+- [x] ApiVersionResponse
+   - [ ] Tests for ApiVersionResponse
+- [x] BasalIQAlertInfoResponse
+   - [ ] Tests for BasalIQAlertInfoResponse
+- [x] BasalIQSettingsResponse
+   - [ ] Tests for BasalIQSettingsResponse
+- [x] BasalIQStatusResponse
+   - [ ] Tests for BasalIQStatusResponse
+- [x] BasalLimitSettingsResponse
+   - [ ] Tests for BasalLimitSettingsResponse
+- [x] BolusCalcDataSnapshotResponse
+   - [ ] Tests for BolusCalcDataSnapshotResponse
+- [x] BolusPermissionChangeReasonResponse
+   - [ ] Tests for BolusPermissionChangeReasonResponse
+- [x] CGMAlertStatusResponse
+   - [ ] Tests for CGMAlertStatusResponse
+- [x] CGMGlucoseAlertSettingsResponse
+   - [ ] Tests for CGMGlucoseAlertSettingsResponse
+- [x] CGMHardwareInfoResponse
+   - [ ] Tests for CGMHardwareInfoResponse
+- [x] CGMOORAlertSettingsResponse
+   - [ ] Tests for CGMOORAlertSettingsResponse
+- [x] CGMRateAlertSettingsResponse
+   - [ ] Tests for CGMRateAlertSettingsResponse
+- [x] CGMStatusResponse
+   - [ ] Tests for CGMStatusResponse
+- [x] CommonSoftwareInfoResponse
+   - [ ] Tests for CommonSoftwareInfoResponse
+- [x] ControlIQIOBResponse
+   - [ ] Tests for ControlIQIOBResponse
+- [x] ControlIQInfoAbstractResponse
+   - [ ] Tests for ControlIQInfoAbstractResponse
+- [x] ControlIQInfoV1Response
+   - [ ] Tests for ControlIQInfoV1Response
+- [x] ControlIQInfoV2Response
+   - [ ] Tests for ControlIQInfoV2Response
+- [x] ControlIQSleepScheduleResponse
+   - [ ] Tests for ControlIQSleepScheduleResponse
+- [x] CurrentBasalStatusResponse
+   - [ ] Tests for CurrentBasalStatusResponse
 - [ ] CurrentBatteryAbstractResponse
-- [ ] CurrentBatteryV1Response
-- [ ] CurrentBatteryV2Response
-- [ ] CurrentBolusStatusResponse
-- [ ] CurrentEGVGuiDataResponse
-- [ ] ExtendedBolusStatusResponse
-- [ ] GetG6TransmitterHardwareInfoResponse
-- [ ] GetSavedG7PairingCodeResponse
-- [ ] GlobalMaxBolusSettingsResponse
-- [ ] HistoryLogResponse
-- [ ] HistoryLogStatusResponse
-- [ ] HomeScreenMirrorResponse
-- [ ] IDPSegmentResponse
-- [ ] IDPSettingsResponse
-- [ ] InsulinStatusResponse
-- [ ] LastBGResponse
+- [x] CurrentBatteryV1Response
+   - [ ] Tests for CurrentBatteryV1Response
+- [x] CurrentBatteryV2Response
+   - [ ] Tests for CurrentBatteryV2Response
+- [x] CurrentBolusStatusResponse
+   - [ ] Tests for CurrentBolusStatusResponse
+- [x] CurrentEGVGuiDataResponse
+   - [ ] Tests for CurrentEGVGuiDataResponse
+- [x] ExtendedBolusStatusResponse
+   - [ ] Tests for ExtendedBolusStatusResponse
+- [x] GetG6TransmitterHardwareInfoResponse
+   - [ ] Tests for GetG6TransmitterHardwareInfoResponse
+- [x] GetSavedG7PairingCodeResponse
+   - [ ] Tests for GetSavedG7PairingCodeResponse
+- [x] GlobalMaxBolusSettingsResponse
+   - [ ] Tests for GlobalMaxBolusSettingsResponse
+- [x] HistoryLogResponse
+   - [ ] Tests for HistoryLogResponse
+- [x] HistoryLogStatusResponse
+   - [ ] Tests for HistoryLogStatusResponse
+- [x] HomeScreenMirrorResponse
+   - [ ] Tests for HomeScreenMirrorResponse
+- [x] IDPSegmentResponse
+   - [ ] Tests for IDPSegmentResponse
+- [x] IDPSettingsResponse
+   - [ ] Tests for IDPSettingsResponse
+- [x] InsulinStatusResponse
+   - [ ] Tests for InsulinStatusResponse
+- [x] LastBGResponse
+   - [ ] Tests for LastBGResponse
 - [ ] LastBolusStatusAbstractResponse
-- [ ] LastBolusStatusResponse
-- [ ] LastBolusStatusV2Response
-- [ ] LocalizationResponse
-- [ ] MalfunctionStatusResponse
-- [ ] NonControlIQIOBResponse
-- [ ] OtherNotification2StatusResponse
-- [ ] OtherNotificationStatusResponse
-- [ ] ProfileStatusResponse
-- [ ] PumpFeaturesAbstractResponse
-- [ ] PumpFeaturesV1Response
-- [ ] PumpFeaturesV2Response
-- [ ] PumpGlobalsResponse
-- [ ] PumpSettingsResponse
-- [ ] PumpVersionResponse
-- [ ] ReminderStatusResponse
-- [ ] RemindersResponse
-- [ ] TempRateResponse
-- [ ] TimeSinceResetResponse
-- [ ] UnknownMobiOpcode110Response
-- [ ] UnknownMobiOpcode20Response
-- [ ] UnknownMobiOpcode30Response
-- [ ] UnknownMobiOpcodeNeg124Response
-- [ ] UnknownMobiOpcodeNeg66Response
-- [ ] UnknownMobiOpcodeNeg70Response
+- [x] LastBolusStatusResponse
+   - [ ] Tests for LastBolusStatusResponse
+- [x] LastBolusStatusV2Response
+   - [ ] Tests for LastBolusStatusV2Response
+- [x] LocalizationResponse
+   - [ ] Tests for LocalizationResponse
+- [x] MalfunctionStatusResponse
+   - [ ] Tests for MalfunctionStatusResponse
+- [x] NonControlIQIOBResponse
+   - [ ] Tests for NonControlIQIOBResponse
+- [x] OtherNotification2StatusResponse
+   - [ ] Tests for OtherNotification2StatusResponse
+- [x] OtherNotificationStatusResponse
+   - [ ] Tests for OtherNotificationStatusResponse
+- [x] ProfileStatusResponse
+   - [ ] Tests for ProfileStatusResponse
+- [x] PumpFeaturesAbstractResponse
+   - [ ] Tests for PumpFeaturesAbstractResponse
+- [x] PumpFeaturesV1Response
+   - [ ] Tests for PumpFeaturesV1Response
+- [x] PumpFeaturesV2Response
+   - [ ] Tests for PumpFeaturesV2Response
+- [x] PumpGlobalsResponse
+   - [ ] Tests for PumpGlobalsResponse
+- [x] PumpSettingsResponse
+   - [ ] Tests for PumpSettingsResponse
+- [x] PumpVersionResponse
+   - [ ] Tests for PumpVersionResponse
+- [x] ReminderStatusResponse
+   - [ ] Tests for ReminderStatusResponse
+- [x] RemindersResponse
+   - [ ] Tests for RemindersResponse
+- [x] TempRateResponse
+   - [ ] Tests for TempRateResponse
+- [x] TimeSinceResetResponse
+   - [ ] Tests for TimeSinceResetResponse
+- [x] UnknownMobiOpcode110Response
+   - [ ] Tests for UnknownMobiOpcode110Response
+- [x] UnknownMobiOpcode20Response
+   - [ ] Tests for UnknownMobiOpcode20Response
+- [x] UnknownMobiOpcode30Response
+   - [ ] Tests for UnknownMobiOpcode30Response
+- [x] UnknownMobiOpcodeNeg124Response
+   - [ ] Tests for UnknownMobiOpcodeNeg124Response
+- [x] UnknownMobiOpcodeNeg66Response
+   - [ ] Tests for UnknownMobiOpcodeNeg66Response
+- [x] UnknownMobiOpcodeNeg70Response
+   - [ ] Tests for UnknownMobiOpcodeNeg70Response
 
 ### HistoryLog
 Requests:


### PR DESCRIPTION
## Summary
- mark message types transferred from pumpx2 as complete and add test tracking checkboxes

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b13311a7ac832ca5bc8cef935cc287