### PR TITLE
Add initial history log support and missing message abstractions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,7 +408,7 @@ Responses:
    - [ ] Tests for InsulinStatusResponse
 - [x] LastBGResponse
    - [ ] Tests for LastBGResponse
-- [ ] LastBolusStatusAbstractResponse
+- [x] LastBolusStatusAbstractResponse
 - [x] LastBolusStatusResponse
    - [ ] Tests for LastBolusStatusResponse
 - [x] LastBolusStatusV2Response
@@ -460,18 +460,18 @@ Responses:
 
 ### HistoryLog
 Requests:
-- [ ] NonexistentHistoryLogStreamRequest
+- [x] NonexistentHistoryLogStreamRequest
 
 Responses:
-- [ ] AlarmActivatedHistoryLog
-- [ ] AlertActivatedHistoryLog
+- [x] AlarmActivatedHistoryLog
+- [x] AlertActivatedHistoryLog
 - [ ] BGHistoryLog
 - [ ] BasalDeliveryHistoryLog
-- [ ] BasalRateChangeHistoryLog
+- [x] BasalRateChangeHistoryLog
 - [ ] BolexActivatedHistoryLog
 - [ ] BolexCompletedHistoryLog
-- [ ] BolusActivatedHistoryLog
-- [ ] BolusCompletedHistoryLog
+- [x] BolusActivatedHistoryLog
+- [x] BolusCompletedHistoryLog
 - [ ] BolusDeliveryHistoryLog
 - [ ] BolusRequestedMsg1HistoryLog
 - [ ] BolusRequestedMsg2HistoryLog
@@ -491,9 +491,9 @@ Responses:
 - [ ] DataLogCorruptionHistoryLog
 - [ ] DateChangeHistoryLog
 - [ ] FactoryResetHistoryLog
-- [ ] HistoryLog
-- [ ] HistoryLogParser
-- [ ] HistoryLogStreamResponse
+- [x] HistoryLog
+- [x] HistoryLogParser
+- [x] HistoryLogStreamResponse
 - [ ] HypoMinimizerResumeHistoryLog
 - [ ] HypoMinimizerSuspendHistoryLog
 - [ ] IdpActionHistoryLog
@@ -507,13 +507,13 @@ Responses:
 - [ ] ParamChangePumpSettingsHistoryLog
 - [ ] ParamChangeRemSettingsHistoryLog
 - [ ] ParamChangeReminderHistoryLog
-- [ ] PumpingResumedHistoryLog
-- [ ] PumpingSuspendedHistoryLog
+- [x] PumpingResumedHistoryLog
+- [x] PumpingSuspendedHistoryLog
 - [ ] TempRateActivatedHistoryLog
 - [ ] TempRateCompletedHistoryLog
 - [ ] TimeChangedHistoryLog
 - [ ] TubingFilledHistoryLog
-- [ ] UnknownHistoryLog
+- [x] UnknownHistoryLog
 - [ ] UsbConnectedHistoryLog
 - [ ] UsbDisconnectedHistoryLog
 - [ ] UsbEnumeratedHistoryLog

--- a/Sources/TandemCore/Messages/Authentication/AbstractPumpChallengeResponse.swift
+++ b/Sources/TandemCore/Messages/Authentication/AbstractPumpChallengeResponse.swift
@@ -1,0 +1,18 @@
+//
+//  AbstractPumpChallengeResponse.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's AbstractPumpChallengeResponse abstract class.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/authentication/AbstractPumpChallengeResponse.java
+//
+
+import Foundation
+
+/// Protocol defining common fields for pump challenge responses.
+public protocol AbstractPumpChallengeResponse: Message {
+    /// App instance identifier echoed back by the pump.
+    var appInstanceId: Int { get }
+}
+

--- a/Sources/TandemCore/Messages/CurrentStatus/LastBolusStatusAbstractResponse.swift
+++ b/Sources/TandemCore/Messages/CurrentStatus/LastBolusStatusAbstractResponse.swift
@@ -22,9 +22,17 @@ public protocol LastBolusStatusAbstractResponse: StatusMessage {
     var extendedBolusDuration: UInt32 { get }
 }
 
+public enum LastBolusStatusAbstractResponseBolusStatus: Int {
+    case stopped = 0
+    case complete = 3
+}
+
 public extension LastBolusStatusAbstractResponse {
+    typealias BolusStatus = LastBolusStatusAbstractResponseBolusStatus
+
     var bolusSource: BolusSource? { BolusSource.fromId(bolusSourceId) }
     var bolusTypes: Set<BolusType> { BolusType.fromBitmask(bolusTypeBitmask) }
+    var bolusStatus: BolusStatus? { BolusStatus(rawValue: bolusStatusId) }
     var timestampDate: Date { Dates.fromJan12008EpochSecondsToDate(TimeInterval(timestamp)) }
 }
 

--- a/Sources/TandemCore/Messages/CurrentStatus/LastBolusStatusAbstractResponse.swift
+++ b/Sources/TandemCore/Messages/CurrentStatus/LastBolusStatusAbstractResponse.swift
@@ -1,0 +1,30 @@
+//
+//  LastBolusStatusAbstractResponse.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Shared fields for last bolus status responses.
+//  Based on PumpX2's LastBolusStatusAbstractResponse.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/LastBolusStatusAbstractResponse.java
+//
+
+import Foundation
+
+/// Protocol capturing fields common to last bolus status responses.
+public protocol LastBolusStatusAbstractResponse: StatusMessage {
+    var bolusId: Int { get }
+    var timestamp: UInt32 { get }
+    var deliveredVolume: UInt32 { get }
+    var bolusStatusId: Int { get }
+    var bolusSourceId: Int { get }
+    var bolusTypeBitmask: Int { get }
+    var extendedBolusDuration: UInt32 { get }
+}
+
+public extension LastBolusStatusAbstractResponse {
+    var bolusSource: BolusSource? { BolusSource.fromId(bolusSourceId) }
+    var bolusTypes: Set<BolusType> { BolusType.fromBitmask(bolusTypeBitmask) }
+    var timestampDate: Date { Dates.fromJan12008EpochSecondsToDate(TimeInterval(timestamp)) }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/AlarmActivatedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/AlarmActivatedHistoryLog.swift
@@ -1,0 +1,44 @@
+//
+//  AlarmActivatedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating an alarm was activated.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlarmActivatedHistoryLog.java
+//
+
+import Foundation
+
+public class AlarmActivatedHistoryLog: HistoryLog {
+    public static let typeId = 5
+
+    public let alarmId: UInt32
+
+    public required init(cargo: Data) {
+        self.alarmId = Bytes.readUint32(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, alarmId: UInt32) {
+        let payload = AlarmActivatedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, alarmId: alarmId)
+        self.alarmId = alarmId
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, alarmId: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(alarmId)
+            )
+        )
+    }
+
+    public var alarmResponseType: AlarmStatusResponse.AlarmResponseType? {
+        AlarmStatusResponse.AlarmResponseType(rawValue: Int(alarmId))
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/AlertActivatedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/AlertActivatedHistoryLog.swift
@@ -1,0 +1,43 @@
+//
+//  AlertActivatedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating an alert was activated.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/AlertActivatedHistoryLog.java
+//
+import Foundation
+
+public class AlertActivatedHistoryLog: HistoryLog {
+    public static let typeId = 4
+
+    public let alertId: UInt32
+
+    public required init(cargo: Data) {
+        self.alertId = Bytes.readUint32(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, alertId: UInt32) {
+        let payload = AlertActivatedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, alertId: alertId)
+        self.alertId = alertId
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, alertId: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(alertId)
+            )
+        )
+    }
+
+    public var alertResponseType: AlertStatusResponse.AlertResponseType? {
+        AlertStatusResponse.AlertResponseType(rawValue: Int(alertId))
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/BasalRateChangeHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BasalRateChangeHistoryLog.swift
@@ -1,0 +1,69 @@
+//
+//  BasalRateChangeHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating a basal rate change.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalRateChangeHistoryLog.java
+//
+import Foundation
+
+public class BasalRateChangeHistoryLog: HistoryLog {
+    public static let typeId = 3
+
+    public let commandBasalRate: Float
+    public let baseBasalRate: Float
+    public let maxBasalRate: Float
+    public let insulinDeliveryProfile: Int
+    public let changeTypeId: Int
+
+    public required init(cargo: Data) {
+        self.commandBasalRate = Bytes.readFloat(cargo, 10)
+        self.baseBasalRate = Bytes.readFloat(cargo, 14)
+        self.maxBasalRate = Bytes.readFloat(cargo, 18)
+        self.insulinDeliveryProfile = Bytes.readShort(cargo, 22)
+        self.changeTypeId = Int(cargo[24])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, commandBasalRate: Float, baseBasalRate: Float, maxBasalRate: Float, insulinDeliveryProfile: Int, changeTypeId: Int) {
+        let payload = BasalRateChangeHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, commandBasalRate: commandBasalRate, baseBasalRate: baseBasalRate, maxBasalRate: maxBasalRate, insulinDeliveryProfile: insulinDeliveryProfile, changeTypeId: changeTypeId)
+        self.commandBasalRate = commandBasalRate
+        self.baseBasalRate = baseBasalRate
+        self.maxBasalRate = maxBasalRate
+        self.insulinDeliveryProfile = insulinDeliveryProfile
+        self.changeTypeId = changeTypeId
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, commandBasalRate: Float, baseBasalRate: Float, maxBasalRate: Float, insulinDeliveryProfile: Int, changeTypeId: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(commandBasalRate),
+                Bytes.toFloat(baseBasalRate),
+                Bytes.toFloat(maxBasalRate),
+                Bytes.firstTwoBytesLittleEndian(insulinDeliveryProfile),
+                Data([UInt8(changeTypeId), 0])
+            )
+        )
+    }
+
+    public enum ChangeType: Int {
+        case timedSegment = 1
+        case newProfile = 2
+        case tempRateStart = 4
+        case tempRateEnd = 8
+        case pumpSuspended = 16
+        case pumpResumed = 32
+        case pumpShutDown = 64
+    }
+
+    public var changeType: ChangeType? {
+        ChangeType(rawValue: changeTypeId)
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/BolusActivatedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BolusActivatedHistoryLog.swift
@@ -1,0 +1,47 @@
+//
+//  BolusActivatedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry when a bolus is activated.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusActivatedHistoryLog.java
+//
+import Foundation
+
+public class BolusActivatedHistoryLog: HistoryLog {
+    public static let typeId = 55
+
+    public let bolusId: Int
+    public let iob: Float
+    public let bolusSize: Float
+
+    public required init(cargo: Data) {
+        self.bolusId = Bytes.readShort(cargo, 10)
+        self.iob = Bytes.readFloat(cargo, 14)
+        self.bolusSize = Bytes.readFloat(cargo, 18)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, bolusId: Int, iob: Float, bolusSize: Float) {
+        let payload = BolusActivatedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, bolusId: bolusId, iob: iob, bolusSize: bolusSize)
+        self.bolusId = bolusId
+        self.iob = iob
+        self.bolusSize = bolusSize
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, bolusId: Int, iob: Float, bolusSize: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(bolusId),
+                Bytes.toFloat(iob),
+                Bytes.toFloat(bolusSize)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/BolusCompletedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BolusCompletedHistoryLog.swift
@@ -1,0 +1,59 @@
+//
+//  BolusCompletedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry when a bolus completes.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusCompletedHistoryLog.java
+//
+import Foundation
+
+public class BolusCompletedHistoryLog: HistoryLog {
+    public static let typeId = 20
+
+    public let completionStatusId: Int
+    public let bolusId: Int
+    public let iob: Float
+    public let insulinDelivered: Float
+    public let insulinRequested: Float
+
+    public required init(cargo: Data) {
+        self.completionStatusId = Bytes.readShort(cargo, 10)
+        self.bolusId = Bytes.readShort(cargo, 12)
+        self.iob = Bytes.readFloat(cargo, 14)
+        self.insulinDelivered = Bytes.readFloat(cargo, 18)
+        self.insulinRequested = Bytes.readFloat(cargo, 22)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, completionStatusId: Int, bolusId: Int, iob: Float, insulinDelivered: Float, insulinRequested: Float) {
+        let payload = BolusCompletedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, completionStatusId: completionStatusId, bolusId: bolusId, iob: iob, insulinDelivered: insulinDelivered, insulinRequested: insulinRequested)
+        self.completionStatusId = completionStatusId
+        self.bolusId = bolusId
+        self.iob = iob
+        self.insulinDelivered = insulinDelivered
+        self.insulinRequested = insulinRequested
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, completionStatusId: Int, bolusId: Int, iob: Float, insulinDelivered: Float, insulinRequested: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(completionStatusId),
+                Bytes.firstTwoBytesLittleEndian(bolusId),
+                Bytes.toFloat(iob),
+                Bytes.toFloat(insulinDelivered),
+                Bytes.toFloat(insulinRequested)
+            )
+        )
+    }
+
+    public var completionStatus: LastBolusStatusAbstractResponse.BolusStatus? {
+        LastBolusStatusAbstractResponse.BolusStatus(rawValue: completionStatusId)
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
@@ -1,0 +1,24 @@
+//
+//  HistoryLogParser.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Simplified parser converting raw history log bytes into known types.
+//
+
+import Foundation
+
+/// Parses raw history log bytes into concrete HistoryLog types.
+public enum HistoryLogParser {
+    public static func parse(_ raw: Data) -> HistoryLog {
+        let typeId = Int(Bytes.readShort(raw, 0) & 0x0FFF)
+        switch typeId {
+        case AlarmActivatedHistoryLog.typeId:
+            return AlarmActivatedHistoryLog(cargo: raw)
+        default:
+            return UnknownHistoryLog(cargo: raw)
+        }
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
@@ -16,6 +16,18 @@ public enum HistoryLogParser {
         switch typeId {
         case AlarmActivatedHistoryLog.typeId:
             return AlarmActivatedHistoryLog(cargo: raw)
+        case AlertActivatedHistoryLog.typeId:
+            return AlertActivatedHistoryLog(cargo: raw)
+        case BasalRateChangeHistoryLog.typeId:
+            return BasalRateChangeHistoryLog(cargo: raw)
+        case BolusActivatedHistoryLog.typeId:
+            return BolusActivatedHistoryLog(cargo: raw)
+        case BolusCompletedHistoryLog.typeId:
+            return BolusCompletedHistoryLog(cargo: raw)
+        case PumpingSuspendedHistoryLog.typeId:
+            return PumpingSuspendedHistoryLog(cargo: raw)
+        case PumpingResumedHistoryLog.typeId:
+            return PumpingResumedHistoryLog(cargo: raw)
         default:
             return UnknownHistoryLog(cargo: raw)
         }

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogRecord.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogRecord.swift
@@ -1,0 +1,40 @@
+//
+//  HistoryLogRecord.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Base class for pump history log records.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLog.java
+//
+
+import Foundation
+
+/// Base class representing a single 26-byte history log entry.
+open class HistoryLog {
+    public static let length = 26
+
+    public let cargo: Data
+    public let typeId: Int
+    public let pumpTimeSec: UInt32
+    public let sequenceNum: UInt32
+
+    public required init(cargo: Data) {
+        let filled = HistoryLog.fillCargo(cargo)
+        self.cargo = filled
+        self.typeId = Int(Bytes.readShort(filled, 0) & 0x0FFF)
+        self.pumpTimeSec = Bytes.readUint32(filled, 2)
+        self.sequenceNum = Bytes.readUint32(filled, 6)
+    }
+
+    /// Pads or truncates cargo to the standard 26-byte length.
+    public static func fillCargo(_ cargo: Data) -> Data {
+        if cargo.count == length {
+            return cargo
+        }
+        var ret = Data(count: length)
+        ret.replaceSubrange(0..<min(cargo.count, length), with: cargo.prefix(length))
+        return ret
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogStream.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogStream.swift
@@ -1,0 +1,80 @@
+//
+//  HistoryLogStream.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representations of NonexistentHistoryLogStreamRequest and HistoryLogStreamResponse.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/request/historyLog/NonexistentHistoryLogStreamRequest.java
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HistoryLogStreamResponse.java
+//
+
+import Foundation
+
+/// Paired request used for HistoryLogStreamResponse, which has no originating request.
+public class NonexistentHistoryLogStreamRequest: Message {
+    public static let props = MessageProps(
+        opCode: 0,
+        size: 0,
+        type: .Request,
+        characteristic: .HISTORY_LOG_CHARACTERISTICS
+    )
+
+    public var cargo: Data
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+    }
+
+    public init() {
+        self.cargo = Data()
+    }
+}
+
+/// Response containing a stream of history log entries.
+public class HistoryLogStreamResponse: Message {
+    public static let props = MessageProps(
+        opCode: UInt8(bitPattern: Int8(-127)),
+        size: 28,
+        type: .Response,
+        characteristic: .HISTORY_LOG_CHARACTERISTICS,
+        variableSize: true,
+        stream: true
+    )
+
+    public var cargo: Data
+    public var numberOfHistoryLogs: Int
+    public var streamId: Int
+    public var historyLogStreamBytes: [Data]
+    public var historyLogs: [HistoryLog]
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+        self.numberOfHistoryLogs = Int(cargo[0])
+        self.streamId = Int(cargo[1])
+
+        var list: [Data] = []
+        var idx = 2
+        while idx + HistoryLog.length <= cargo.count {
+            list.append(cargo.subdata(in: idx..<(idx + HistoryLog.length)))
+            idx += HistoryLog.length
+        }
+        self.historyLogStreamBytes = list
+        self.historyLogs = list.map { HistoryLogParser.parse($0) }
+    }
+
+    public init(numberOfHistoryLogs: Int, streamId: Int, historyLogStreamBytes: [Data]) {
+        var combined = Data()
+        historyLogStreamBytes.forEach { combined.append($0) }
+        self.cargo = Bytes.combine(
+            Data([UInt8(numberOfHistoryLogs)]),
+            Data([UInt8(streamId)]),
+            combined
+        )
+        self.numberOfHistoryLogs = numberOfHistoryLogs
+        self.streamId = streamId
+        self.historyLogStreamBytes = historyLogStreamBytes
+        self.historyLogs = historyLogStreamBytes.map { HistoryLogParser.parse($0) }
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/PumpingResumedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/PumpingResumedHistoryLog.swift
@@ -1,0 +1,40 @@
+//
+//  PumpingResumedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating pumping was resumed.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingResumedHistoryLog.java
+//
+import Foundation
+
+public class PumpingResumedHistoryLog: HistoryLog {
+    public static let typeId = 12
+
+    public let insulinAmount: Int
+
+    public required init(cargo: Data) {
+        self.insulinAmount = Bytes.readShort(cargo, 14)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinAmount: Int) {
+        let payload = PumpingResumedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, insulinAmount: insulinAmount)
+        self.insulinAmount = insulinAmount
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinAmount: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data(repeating: 0, count: 4),
+                Bytes.firstTwoBytesLittleEndian(insulinAmount)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/PumpingSuspendedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/PumpingSuspendedHistoryLog.swift
@@ -1,0 +1,55 @@
+//
+//  PumpingSuspendedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating pumping was suspended.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/PumpingSuspendedHistoryLog.java
+//
+import Foundation
+
+public class PumpingSuspendedHistoryLog: HistoryLog {
+    public static let typeId = 11
+
+    public let insulinAmount: Int
+    public let reasonId: Int
+
+    public required init(cargo: Data) {
+        self.insulinAmount = Bytes.readShort(cargo, 14)
+        self.reasonId = Int(cargo[16])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinAmount: Int, reasonId: Int) {
+        let payload = PumpingSuspendedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, insulinAmount: insulinAmount, reasonId: reasonId)
+        self.insulinAmount = insulinAmount
+        self.reasonId = reasonId
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinAmount: Int, reasonId: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data(repeating: 0, count: 4),
+                Bytes.firstTwoBytesLittleEndian(insulinAmount),
+                Data([UInt8(reasonId)])
+            )
+        )
+    }
+
+    public enum SuspendReason: Int {
+        case userAborted = 0
+        case alarm = 1
+        case malfunction = 2
+        case autoSuspendPredictiveLowGlucose = 6
+    }
+
+    public var reason: SuspendReason? {
+        SuspendReason(rawValue: reasonId)
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/UnknownHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/UnknownHistoryLog.swift
@@ -1,0 +1,18 @@
+//
+//  UnknownHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Fallback history log entry used when a specific type is not implemented.
+//
+
+import Foundation
+
+/// History log type used when a specific implementation is unavailable.
+public class UnknownHistoryLog: HistoryLog {
+    public required init(cargo: Data) {
+        super.init(cargo: cargo)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `AbstractPumpChallengeResponse` protocol
- add `LastBolusStatusAbstractResponse` shared protocol
- implement history log infrastructure with stream handling and an Alarm Activated log

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b1353ec060832c9c304bf8dfc24826