### PR TITLE
Add pump state stream, battery abstraction, and history logs

### DIFF
--- a/Sources/TandemCore/Messages/ControlStream/NonexistentPumpingStateStream.swift
+++ b/Sources/TandemCore/Messages/ControlStream/NonexistentPumpingStateStream.swift
@@ -1,0 +1,95 @@
+//
+//  NonexistentPumpingStateStream.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representations of NonexistentPumpingStateStreamRequest and PumpingStateStreamResponse based on
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/request/controlStream/NonexistentPumpingStateStreamRequest.java
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/controlStream/PumpingStateStreamResponse.java
+//
+import Foundation
+
+/// Placeholder request for PumpingStateStreamResponse which has no originating request.
+public class NonexistentPumpingStateStreamRequest: Message {
+    public static let props = MessageProps(
+        opCode: 0,
+        size: 0,
+        type: .Request,
+        characteristic: .CONTROL_STREAM_CHARACTERISTICS,
+        stream: true,
+        signed: true
+    )
+
+    public var cargo: Data
+
+    public required init(cargo: Data) {
+        self.cargo = cargo
+    }
+
+    public init() {
+        self.cargo = Data()
+    }
+}
+
+/// Stream response containing pump state bitmask information.
+public class PumpingStateStreamResponse: Message {
+    public static let props = MessageProps(
+        opCode: UInt8(bitPattern: Int8(-23)),
+        size: 5,
+        type: .Response,
+        characteristic: .CONTROL_STREAM_CHARACTERISTICS,
+        stream: true,
+        signed: true
+    )
+
+    public var cargo: Data
+    public var isPumpingStateSetAfterStartUp: Bool
+    public var stateBitmask: UInt32
+
+    public required init(cargo: Data) {
+        let raw = Bytes.dropLastN(cargo, 24)
+        self.cargo = raw
+        self.isPumpingStateSetAfterStartUp = raw[0] != 0
+        self.stateBitmask = Bytes.readUint32(raw, 1)
+    }
+
+    public init(isPumpingStateSetAfterStartUp: Bool, stateBitmask: UInt32) {
+        self.cargo = Bytes.combine(
+            Data([isPumpingStateSetAfterStartUp ? 1 : 0]),
+            Bytes.toUint32(stateBitmask)
+        )
+        self.isPumpingStateSetAfterStartUp = isPumpingStateSetAfterStartUp
+        self.stateBitmask = stateBitmask
+    }
+
+    public var states: Set<PumpingState> {
+        var result: Set<PumpingState> = []
+        for state in PumpingState.allCases {
+            if (stateBitmask & state.rawValue) != 0 {
+                result.insert(state)
+            }
+        }
+        return result
+    }
+
+    public enum PumpingState: UInt32, CaseIterable {
+        case isDeliveringTherapy = 1
+        case canResumeTherapy = 2
+        case canAutoResume = 4
+        case bolusAllowed = 8
+        case tubingFilled = 16
+        case deliveringBasal = 32
+        case deliveringBolus = 64
+        case deliveringNormalBolus = 128
+        case isFillTubingAllowed = 256
+        case isBasalState = 512
+        case isPrepCartridgeState = 1024
+        case isLoadCartridgeState = 2048
+        case isFillState = 4096
+        case isEstimateState = 8192
+        case cartridgeIsInstalled = 16384
+        case canSnooze = 32768
+    }
+}
+

--- a/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryAbstractResponse.swift
+++ b/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryAbstractResponse.swift
@@ -1,0 +1,24 @@
+//
+//  CurrentBatteryAbstractResponse.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's CurrentBatteryAbstractResponse.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/currentStatus/CurrentBatteryAbstractResponse.java
+//
+import Foundation
+
+/// Protocol defining common fields for current battery responses.
+public protocol CurrentBatteryAbstractResponse: Message {
+    /// Unused battery capacity percentage.
+    var currentBatteryAbc: Int { get }
+    /// Used battery capacity percentage displayed by the pump UI.
+    var currentBatteryIbc: Int { get }
+}
+
+extension CurrentBatteryAbstractResponse {
+    /// Convenience accessor mapping to battery percent used by the pump UI.
+    public var batteryPercent: Int { currentBatteryIbc }
+}
+

--- a/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryV1.swift
+++ b/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryV1.swift
@@ -65,3 +65,5 @@ public class CurrentBatteryV1Response: Message {
     }
 }
 
+
+extension CurrentBatteryV1Response: CurrentBatteryAbstractResponse {}

--- a/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryV2.swift
+++ b/Sources/TandemCore/Messages/CurrentStatus/CurrentBatteryV2.swift
@@ -92,3 +92,5 @@ public class CurrentBatteryV2Response: Message {
     }
 }
 
+
+extension CurrentBatteryV2Response: CurrentBatteryAbstractResponse {}

--- a/Sources/TandemCore/Messages/HistoryLog/BGHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BGHistoryLog.swift
@@ -1,0 +1,70 @@
+//
+//  BGHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's BGHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BGHistoryLog.java
+//
+import Foundation
+
+/// History log entry recording a manual or CGM blood glucose reading.
+public class BGHistoryLog: HistoryLog {
+    public static let typeId = 16
+
+    public let bg: Int
+    public let cgmCalibration: Int
+    public let bgSourceId: Int
+    public let iob: Float
+    public let targetBG: Int
+    public let isf: Int
+    public let spare: UInt32
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.bg = Bytes.readShort(raw, 10)
+        self.cgmCalibration = Int(raw[12])
+        self.bgSourceId = Int(raw[13])
+        self.iob = Bytes.readFloat(raw, 14)
+        self.targetBG = Bytes.readShort(raw, 18)
+        self.isf = Bytes.readShort(raw, 20)
+        self.spare = Bytes.readUint32(raw, 22)
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, bg: Int, cgmCalibration: Int, bgSourceId: Int, iob: Float, targetBG: Int, isf: Int, spare: UInt32) {
+        let payload = BGHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, bg: bg, cgmCalibration: cgmCalibration, bgSourceId: bgSourceId, iob: iob, targetBG: targetBG, isf: isf, spare: spare)
+        self.bg = bg
+        self.cgmCalibration = cgmCalibration
+        self.bgSourceId = bgSourceId
+        self.iob = iob
+        self.targetBG = targetBG
+        self.isf = isf
+        self.spare = spare
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, bg: Int, cgmCalibration: Int, bgSourceId: Int, iob: Float, targetBG: Int, isf: Int, spare: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(bg),
+                Data([UInt8(cgmCalibration & 0xFF)]),
+                Data([UInt8(bgSourceId & 0xFF)]),
+                Bytes.toFloat(iob),
+                Bytes.firstTwoBytesLittleEndian(targetBG),
+                Bytes.firstTwoBytesLittleEndian(isf),
+                Bytes.toUint32(spare)
+            )
+        )
+    }
+
+    /// Source of the BG entry (CGM or manual).
+    public var bgSource: LastBGResponse.BgSource? {
+        return LastBGResponse.BgSource(rawValue: bgSourceId)
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/BasalDeliveryHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BasalDeliveryHistoryLog.swift
@@ -1,0 +1,57 @@
+//
+//  BasalDeliveryHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's BasalDeliveryHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BasalDeliveryHistoryLog.java
+//
+import Foundation
+
+/// History log entry detailing basal rate delivery.
+public class BasalDeliveryHistoryLog: HistoryLog {
+    public static let typeId = 279
+
+    public let commandedRateSource: Int
+    public let commandedRate: Int
+    public let profileBasalRate: Int
+    public let algorithmRate: Int
+    public let tempRate: Int
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.commandedRateSource = Bytes.readShort(raw, 10)
+        self.commandedRate = Bytes.readShort(raw, 14)
+        self.profileBasalRate = Bytes.readShort(raw, 16)
+        self.algorithmRate = Bytes.readShort(raw, 18)
+        self.tempRate = Bytes.readShort(raw, 20)
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, commandedRateSource: Int, commandedRate: Int, profileBasalRate: Int, algorithmRate: Int, tempRate: Int) {
+        let payload = BasalDeliveryHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, commandedRateSource: commandedRateSource, commandedRate: commandedRate, profileBasalRate: profileBasalRate, algorithmRate: algorithmRate, tempRate: tempRate)
+        self.commandedRateSource = commandedRateSource
+        self.commandedRate = commandedRate
+        self.profileBasalRate = profileBasalRate
+        self.algorithmRate = algorithmRate
+        self.tempRate = tempRate
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, commandedRateSource: Int, commandedRate: Int, profileBasalRate: Int, algorithmRate: Int, tempRate: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([23, 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(commandedRateSource),
+                Bytes.firstTwoBytesLittleEndian(commandedRate),
+                Bytes.firstTwoBytesLittleEndian(profileBasalRate),
+                Bytes.firstTwoBytesLittleEndian(algorithmRate),
+                Bytes.firstTwoBytesLittleEndian(tempRate)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/BolusDeliveryHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/BolusDeliveryHistoryLog.swift
@@ -1,0 +1,111 @@
+//
+//  BolusDeliveryHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's BolusDeliveryHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/BolusDeliveryHistoryLog.java
+//
+import Foundation
+
+/// History log entry describing bolus delivery details.
+public class BolusDeliveryHistoryLog: HistoryLog {
+    public static let typeId = 280
+
+    public let bolusID: Int
+    public let bolusDeliveryStatus: Int
+    public let bolusTypeBitmask: Int
+    public let bolusSource: Int
+    public let reserved: Int
+    public let requestedNow: Int
+    public let requestedLater: Int
+    public let correction: Int
+    public let extendedDurationRequested: Int
+    public let deliveredTotal: Int
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.bolusID = Bytes.readShort(raw, 10)
+        self.bolusDeliveryStatus = Int(raw[12])
+        self.bolusTypeBitmask = Int(raw[13])
+        self.bolusSource = Int(raw[14])
+        self.reserved = Int(raw[15])
+        self.requestedNow = Bytes.readShort(raw, 16)
+        self.requestedLater = Bytes.readShort(raw, 18)
+        self.correction = Bytes.readShort(raw, 20)
+        self.extendedDurationRequested = Bytes.readShort(raw, 22)
+        self.deliveredTotal = Bytes.readShort(raw, 24)
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, bolusID: Int, bolusDeliveryStatus: Int, bolusTypeBitmask: Int, bolusSource: Int, reserved: Int, requestedNow: Int, requestedLater: Int, correction: Int, extendedDurationRequested: Int, deliveredTotal: Int) {
+        let payload = BolusDeliveryHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, bolusID: bolusID, bolusDeliveryStatus: bolusDeliveryStatus, bolusTypeBitmask: bolusTypeBitmask, bolusSource: bolusSource, reserved: reserved, requestedNow: requestedNow, requestedLater: requestedLater, correction: correction, extendedDurationRequested: extendedDurationRequested, deliveredTotal: deliveredTotal)
+        self.bolusID = bolusID
+        self.bolusDeliveryStatus = bolusDeliveryStatus
+        self.bolusTypeBitmask = bolusTypeBitmask
+        self.bolusSource = bolusSource
+        self.reserved = reserved
+        self.requestedNow = requestedNow
+        self.requestedLater = requestedLater
+        self.correction = correction
+        self.extendedDurationRequested = extendedDurationRequested
+        self.deliveredTotal = deliveredTotal
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, bolusID: Int, bolusDeliveryStatus: Int, bolusTypeBitmask: Int, bolusSource: Int, reserved: Int, requestedNow: Int, requestedLater: Int, correction: Int, extendedDurationRequested: Int, deliveredTotal: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([24, 1]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(bolusID),
+                Data([UInt8(bolusDeliveryStatus & 0xFF)]),
+                Data([UInt8(bolusTypeBitmask & 0xFF)]),
+                Data([UInt8(bolusSource & 0xFF)]),
+                Data([UInt8(reserved & 0xFF)]),
+                Bytes.firstTwoBytesLittleEndian(requestedNow),
+                Bytes.firstTwoBytesLittleEndian(requestedLater),
+                Bytes.firstTwoBytesLittleEndian(correction),
+                Bytes.firstTwoBytesLittleEndian(extendedDurationRequested),
+                Bytes.firstTwoBytesLittleEndian(deliveredTotal)
+            )
+        )
+    }
+
+    /// Set of bolus types associated with this record.
+    public var bolusTypes: Set<BolusType> { BolusType.fromBitmask(bolusTypeBitmask) }
+
+    /// Source that initiated the bolus.
+    public var bolusSourceEnum: BolusSource? { BolusSource(rawValue: bolusSource) }
+
+    public enum BolusSource: Int {
+        case quickBolus = 0
+        case gui = 1
+        case controlIQAutoBolus = 7
+        case bluetoothRemoteBolus = 8
+    }
+
+    public enum BolusType: Int, CaseIterable {
+        case food1 = 1
+        case correction = 2
+        case extended = 4
+        case food2 = 8
+
+        public static func fromBitmask(_ bitmask: Int) -> Set<BolusType> {
+            var ret: Set<BolusType> = []
+            for t in BolusType.allCases {
+                if (bitmask & t.rawValue) != 0 {
+                    ret.insert(t)
+                }
+            }
+            return ret
+        }
+
+        public static func toBitmask(_ types: [BolusType]) -> Int {
+            return types.reduce(0) { $0 | $1.rawValue }
+        }
+    }
+}
+

--- a/Sources/TandemCore/Messages/QualifyingEvent/QualifyingEvent.swift
+++ b/Sources/TandemCore/Messages/QualifyingEvent/QualifyingEvent.swift
@@ -1,0 +1,118 @@
+//
+//  QualifyingEvent.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's QualifyingEvent enumeration.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/qualifyingEvent/QualifyingEvent.java
+//
+import Foundation
+
+/// Message factories used to fetch additional details for a qualifying event.
+public typealias MessageFactory = () -> Message
+
+/// A list of events which can be emitted by the pump, along with suggested
+/// request messages that may be sent to obtain further details.
+public enum QualifyingEvent: CaseIterable {
+    case alert
+    case alarm
+    case reminder
+    case malfunction
+    case cgmAlert
+    case homeScreenChange
+    case pumpSuspend
+    case pumpResume
+    case timeChange
+    case basalChange
+    case bolusChange
+    case iobChange
+    case extendedBolusChange
+    case profileChange
+    case bg
+    case cgmChange
+    case battery
+    case basalIQ
+    case remainingInsulin
+    case suspendComm
+    case activeSegmentChange
+    case basalIQStatus
+    case controlIQInfo
+    case controlIQSleep
+    case bolusPermissionRevoked
+
+    /// Identifier used in bitmasks from the pump.
+    public var id: UInt32 {
+        switch self {
+        case .alert: return 1
+        case .alarm: return 2
+        case .reminder: return 4
+        case .malfunction: return 8
+        case .cgmAlert: return 16
+        case .homeScreenChange: return 32
+        case .pumpSuspend: return 64
+        case .pumpResume: return 128
+        case .timeChange: return 256
+        case .basalChange: return 512
+        case .bolusChange: return 1024
+        case .iobChange: return 2048
+        case .extendedBolusChange: return 4096
+        case .profileChange: return 8192
+        case .bg: return 16384
+        case .cgmChange: return 32768
+        case .battery: return 65536
+        case .basalIQ: return 131072
+        case .remainingInsulin: return 262144
+        case .suspendComm: return 524288
+        case .activeSegmentChange: return 1048576
+        case .basalIQStatus: return 2097152
+        case .controlIQInfo: return 4194304
+        case .controlIQSleep: return 8388608
+        case .bolusPermissionRevoked: return 2147483648
+        }
+    }
+
+    /// Suggested request messages to handle this event. Currently unimplemented.
+    public var suggestedHandlers: [MessageFactory] { [] }
+
+    /// Convert a bitmask into a set of QualifyingEvents.
+    public static func fromBitmask(_ bitmask: UInt32) -> Set<QualifyingEvent> {
+        var ret: Set<QualifyingEvent> = []
+        for event in QualifyingEvent.allCases {
+            if (bitmask & event.id) != 0 {
+                ret.insert(event)
+            }
+        }
+        return ret
+    }
+
+    /// Parse a 4-byte little-endian bitmask from raw Bluetooth data.
+    public static func fromRawBytes(_ raw: Data) -> Set<QualifyingEvent> {
+        return fromBitmask(Bytes.readUint32(raw, 0))
+    }
+
+    /// Return suggested request messages for a set of events.
+    public static func groupSuggestedHandlers(_ events: Set<QualifyingEvent>) -> [Message] {
+        var messages: [Message] = []
+        for e in events {
+            for factory in e.suggestedHandlers {
+                messages.append(factory())
+            }
+        }
+        // remove duplicates by opcode
+        var seen: Set<UInt8> = []
+        messages = messages.filter { msg in
+            let op = type(of: msg).props.opCode
+            if seen.contains(op) { return false }
+            seen.insert(op)
+            return true
+        }
+        return messages
+    }
+
+    /// Construct a bitmask from multiple events.
+    public static func toBitmask(_ events: [QualifyingEvent]) -> UInt32 {
+        return events.reduce(0) { $0 | $1.id }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add NonexistentPumpingStateStream request/response
- introduce CurrentBatteryAbstractResponse protocol and conforming implementations
- port BG, basal delivery, and bolus delivery history logs
- add QualifyingEvent enum skeleton

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b138de98e4832caa58fa4ff756050a