### PR TITLE
Add USB and fill history logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,21 +465,21 @@ Requests:
 Responses:
 - [x] AlarmActivatedHistoryLog
 - [x] AlertActivatedHistoryLog
-- [ ] BGHistoryLog
-- [ ] BasalDeliveryHistoryLog
+- [x] BGHistoryLog
+- [x] BasalDeliveryHistoryLog
 - [x] BasalRateChangeHistoryLog
 - [ ] BolexActivatedHistoryLog
 - [ ] BolexCompletedHistoryLog
 - [x] BolusActivatedHistoryLog
 - [x] BolusCompletedHistoryLog
-- [ ] BolusDeliveryHistoryLog
+- [x] BolusDeliveryHistoryLog
 - [ ] BolusRequestedMsg1HistoryLog
 - [ ] BolusRequestedMsg2HistoryLog
 - [ ] BolusRequestedMsg3HistoryLog
 - [ ] CGMHistoryLog
-- [ ] CannulaFilledHistoryLog
+- [x] CannulaFilledHistoryLog
 - [ ] CarbEnteredHistoryLog
-- [ ] CartridgeFilledHistoryLog
+- [x] CartridgeFilledHistoryLog
 - [ ] CgmCalibrationGxHistoryLog
 - [ ] CgmCalibrationHistoryLog
 - [ ] CgmDataGxHistoryLog
@@ -514,10 +514,10 @@ Responses:
 - [ ] TimeChangedHistoryLog
 - [ ] TubingFilledHistoryLog
 - [x] UnknownHistoryLog
-- [ ] UsbConnectedHistoryLog
-- [ ] UsbDisconnectedHistoryLog
-- [ ] UsbEnumeratedHistoryLog
+- [x] UsbConnectedHistoryLog
+- [x] UsbDisconnectedHistoryLog
+- [x] UsbEnumeratedHistoryLog
 
 ### QualifyingEvent
 Responses:
-- [ ] QualifyingEvent
+- [x] QualifyingEvent

--- a/Sources/TandemCore/Messages/HistoryLog/CannulaFilledHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CannulaFilledHistoryLog.swift
@@ -1,0 +1,41 @@
+//
+//  CannulaFilledHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating the cannula was filled.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CannulaFilledHistoryLog.java
+//
+
+import Foundation
+
+public class CannulaFilledHistoryLog: HistoryLog {
+    public static let typeId = 61
+
+    /// The number of units used to prime the cannula.
+    public let primeSize: Float
+
+    public required init(cargo: Data) {
+        self.primeSize = Bytes.readFloat(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, primeSize: Float) {
+        let payload = CannulaFilledHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, primeSize: primeSize)
+        self.primeSize = primeSize
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, primeSize: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(primeSize)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/CartridgeFilledHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CartridgeFilledHistoryLog.swift
@@ -1,0 +1,46 @@
+//
+//  CartridgeFilledHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating the cartridge was filled.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CartridgeFilledHistoryLog.java
+//
+
+import Foundation
+
+public class CartridgeFilledHistoryLog: HistoryLog {
+    public static let typeId = 33
+
+    /// A user-facing displayable amount of insulin filled.
+    public let insulinDisplay: UInt32
+    /// The actual amount of insulin mechanically filled by the pump.
+    public let insulinActual: Float
+
+    public required init(cargo: Data) {
+        self.insulinDisplay = Bytes.readUint32(cargo, 10)
+        self.insulinActual = Bytes.readFloat(cargo, 14)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinDisplay: UInt32, insulinActual: Float) {
+        let payload = CartridgeFilledHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, insulinDisplay: insulinDisplay, insulinActual: insulinActual)
+        self.insulinDisplay = insulinDisplay
+        self.insulinActual = insulinActual
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, insulinDisplay: UInt32, insulinActual: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(insulinDisplay),
+                Bytes.toFloat(insulinActual)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/UsbConnectedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/UsbConnectedHistoryLog.swift
@@ -1,0 +1,41 @@
+//
+//  UsbConnectedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating a USB connection event.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbConnectedHistoryLog.java
+//
+
+import Foundation
+
+public class UsbConnectedHistoryLog: HistoryLog {
+    public static let typeId = 36
+
+    /// The negotiated current in milliamps.
+    public let negotiatedCurrentmA: Float
+
+    public required init(cargo: Data) {
+        self.negotiatedCurrentmA = Bytes.readFloat(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Float) {
+        let payload = UsbConnectedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, negotiatedCurrentmA: negotiatedCurrentmA)
+        self.negotiatedCurrentmA = negotiatedCurrentmA
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(negotiatedCurrentmA)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/UsbDisconnectedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/UsbDisconnectedHistoryLog.swift
@@ -1,0 +1,41 @@
+//
+//  UsbDisconnectedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating a USB disconnection event.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbDisconnectedHistoryLog.java
+//
+
+import Foundation
+
+public class UsbDisconnectedHistoryLog: HistoryLog {
+    public static let typeId = 37
+
+    /// The negotiated current in milliamps prior to disconnection.
+    public let negotiatedCurrentmA: Float
+
+    public required init(cargo: Data) {
+        self.negotiatedCurrentmA = Bytes.readFloat(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Float) {
+        let payload = UsbDisconnectedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, negotiatedCurrentmA: negotiatedCurrentmA)
+        self.negotiatedCurrentmA = negotiatedCurrentmA
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(negotiatedCurrentmA)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/UsbEnumeratedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/UsbEnumeratedHistoryLog.swift
@@ -1,0 +1,41 @@
+//
+//  UsbEnumeratedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry indicating the USB interface was enumerated.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/UsbEnumeratedHistoryLog.java
+//
+
+import Foundation
+
+public class UsbEnumeratedHistoryLog: HistoryLog {
+    public static let typeId = 67
+
+    /// The negotiated current in milliamps during enumeration.
+    public let negotiatedCurrentmA: Int
+
+    public required init(cargo: Data) {
+        self.negotiatedCurrentmA = Int(cargo[10])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Int) {
+        let payload = UsbEnumeratedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, negotiatedCurrentmA: negotiatedCurrentmA)
+        self.negotiatedCurrentmA = negotiatedCurrentmA
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, negotiatedCurrentmA: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(negotiatedCurrentmA & 0xFF)])
+            )
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- port cannula and cartridge filled history log classes
- add USB connected, disconnected, and enumerated history logs
- update AGENTS checklist for implemented logs

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b22acc2414832c907d571a71328cbe