### PR TITLE
Add CGM calibration and data history logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Requests:
 Responses:
 - [x] AbstractCentralChallengeResponse
    - [ ] Tests for AbstractCentralChallengeResponse
-- [ ] AbstractPumpChallengeResponse
+- [x] AbstractPumpChallengeResponse
 - [x] CentralChallengeResponse
    - [ ] Tests for CentralChallengeResponse
 - [x] Jpake1aResponse
@@ -480,10 +480,10 @@ Responses:
 - [x] CannulaFilledHistoryLog
 - [x] CarbEnteredHistoryLog
 - [x] CartridgeFilledHistoryLog
-- [ ] CgmCalibrationGxHistoryLog
-- [ ] CgmCalibrationHistoryLog
-- [ ] CgmDataGxHistoryLog
-- [ ] CgmDataSampleHistoryLog
+- [x] CgmCalibrationGxHistoryLog
+- [x] CgmCalibrationHistoryLog
+- [x] CgmDataGxHistoryLog
+- [x] CgmDataSampleHistoryLog
 - [ ] ControlIQPcmChangeHistoryLog
 - [ ] ControlIQUserModeChangeHistoryLog
 - [ ] CorrectionDeclinedHistoryLog

--- a/Sources/TandemCore/Messages/HistoryLog/CgmCalibrationGxHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CgmCalibrationGxHistoryLog.swift
@@ -1,0 +1,40 @@
+//
+//  CgmCalibrationGxHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's CgmCalibrationGxHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationGxHistoryLog.java
+//
+
+import Foundation
+
+/// History log entry for GX CGM calibration value.
+public class CgmCalibrationGxHistoryLog: HistoryLog {
+    public static let typeId = 210
+
+    public let value: Int
+
+    public required init(cargo: Data) {
+        self.value = Bytes.readShort(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, value: Int) {
+        let payload = CgmCalibrationGxHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, value: value)
+        self.value = value
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, value: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(value)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/CgmCalibrationHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CgmCalibrationHistoryLog.swift
@@ -1,0 +1,56 @@
+//
+//  CgmCalibrationHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's CgmCalibrationHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmCalibrationHistoryLog.java
+//
+
+import Foundation
+
+/// History log entry recording a CGM calibration event.
+public class CgmCalibrationHistoryLog: HistoryLog {
+    public static let typeId = 160
+
+    public let currentTime: UInt32
+    public let timestamp: UInt32
+    public let calTimestamp: UInt32
+    public let value: Int
+    public let currentDisplayValue: Int
+
+    public required init(cargo: Data) {
+        self.currentTime = Bytes.readUint32(cargo, 10)
+        self.timestamp = Bytes.readUint32(cargo, 14)
+        self.calTimestamp = Bytes.readUint32(cargo, 18)
+        self.value = Bytes.readShort(cargo, 22)
+        self.currentDisplayValue = Bytes.readShort(cargo, 24)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, currentTime: UInt32, timestamp: UInt32, calTimestamp: UInt32, value: Int, currentDisplayValue: Int) {
+        let payload = CgmCalibrationHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, currentTime: currentTime, timestamp: timestamp, calTimestamp: calTimestamp, value: value, currentDisplayValue: currentDisplayValue)
+        self.currentTime = currentTime
+        self.timestamp = timestamp
+        self.calTimestamp = calTimestamp
+        self.value = value
+        self.currentDisplayValue = currentDisplayValue
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, currentTime: UInt32, timestamp: UInt32, calTimestamp: UInt32, value: Int, currentDisplayValue: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(currentTime),
+                Bytes.toUint32(timestamp),
+                Bytes.toUint32(calTimestamp),
+                Bytes.firstTwoBytesLittleEndian(value),
+                Bytes.firstTwoBytesLittleEndian(currentDisplayValue)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/CgmDataGxHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CgmDataGxHistoryLog.swift
@@ -1,0 +1,64 @@
+//
+//  CgmDataGxHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's CgmDataGxHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataGxHistoryLog.java
+//
+
+import Foundation
+
+/// History log entry containing a GX CGM data sample.
+public class CgmDataGxHistoryLog: HistoryLog {
+    public static let typeId = 211
+
+    public let status: Int
+    public let type: Int
+    public let rate: Int
+    public let rssi: Int
+    public let value: Int
+    public let timestamp: UInt32
+    public let transmitterTimestamp: UInt32
+
+    public required init(cargo: Data) {
+        self.status = Bytes.readShort(cargo, 10)
+        self.type = Int(cargo[12])
+        self.rate = Int(cargo[13])
+        self.rssi = Int(cargo[15])
+        self.value = Bytes.readShort(cargo, 16)
+        self.timestamp = Bytes.readUint32(cargo, 18)
+        self.transmitterTimestamp = Bytes.readUint32(cargo, 22)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, status: Int, type: Int, rate: Int, rssi: Int, value: Int, timestamp: UInt32, transmitterTimestamp: UInt32) {
+        let payload = CgmDataGxHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, status: status, type: type, rate: rate, rssi: rssi, value: value, timestamp: timestamp, transmitterTimestamp: transmitterTimestamp)
+        self.status = status
+        self.type = type
+        self.rate = rate
+        self.rssi = rssi
+        self.value = value
+        self.timestamp = timestamp
+        self.transmitterTimestamp = transmitterTimestamp
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, status: Int, type: Int, rate: Int, rssi: Int, value: Int, timestamp: UInt32, transmitterTimestamp: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(status),
+                Data([UInt8(type & 0xFF)]),
+                Data([UInt8(rate & 0xFF)]),
+                Data([UInt8(rssi & 0xFF)]),
+                Bytes.firstTwoBytesLittleEndian(value),
+                Bytes.toUint32(timestamp),
+                Bytes.toUint32(transmitterTimestamp)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/CgmDataSampleHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CgmDataSampleHistoryLog.swift
@@ -1,0 +1,44 @@
+//
+//  CgmDataSampleHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's CgmDataSampleHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CgmDataSampleHistoryLog.java
+//
+
+import Foundation
+
+/// History log entry containing a CGM data sample.
+public class CgmDataSampleHistoryLog: HistoryLog {
+    public static let typeId = 151
+
+    public let status: Int
+    public let value: Int
+
+    public required init(cargo: Data) {
+        self.status = Bytes.readShort(cargo, 10)
+        self.value = Bytes.readShort(cargo, 19)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, status: Int, value: Int) {
+        let payload = CgmDataSampleHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, status: status, value: value)
+        self.status = status
+        self.value = value
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, status: Int, value: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(status),
+                Bytes.firstTwoBytesLittleEndian(value)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
@@ -24,6 +24,16 @@ public enum HistoryLogParser {
             return BolusActivatedHistoryLog(cargo: raw)
         case BolusCompletedHistoryLog.typeId:
             return BolusCompletedHistoryLog(cargo: raw)
+        case CGMHistoryLog.typeId:
+            return CGMHistoryLog(cargo: raw)
+        case CgmCalibrationHistoryLog.typeId:
+            return CgmCalibrationHistoryLog(cargo: raw)
+        case CgmCalibrationGxHistoryLog.typeId:
+            return CgmCalibrationGxHistoryLog(cargo: raw)
+        case CgmDataSampleHistoryLog.typeId:
+            return CgmDataSampleHistoryLog(cargo: raw)
+        case CgmDataGxHistoryLog.typeId:
+            return CgmDataGxHistoryLog(cargo: raw)
         case PumpingSuspendedHistoryLog.typeId:
             return PumpingSuspendedHistoryLog(cargo: raw)
         case PumpingResumedHistoryLog.typeId:


### PR DESCRIPTION
## Summary
- add CGM calibration and data history log types
- update HistoryLogParser to recognize new CGM entries
- mark new history log classes in AGENTS checklist

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3cef760832ca57517681b4da713