### PR TITLE
Add tests for initial authentication requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,17 +5,17 @@ Requests:
 - [x] AbstractCentralChallengeRequest
    - [ ] Tests for AbstractCentralChallengeRequest
 - [x] CentralChallengeRequest
-   - [ ] Tests for CentralChallengeRequest
+   - [x] Tests for CentralChallengeRequest
 - [x] Jpake1aRequest
    - [x] Tests for Jpake1aRequest
 - [x] Jpake1bRequest
-   - [ ] Tests for Jpake1bRequest
+   - [x] Tests for Jpake1bRequest
 - [x] Jpake2Request
-   - [ ] Tests for Jpake2Request
+   - [x] Tests for Jpake2Request
 - [x] Jpake3SessionKeyRequest
-   - [ ] Tests for Jpake3SessionKeyRequest
+   - [x] Tests for Jpake3SessionKeyRequest
 - [x] Jpake4KeyConfirmationRequest
-   - [ ] Tests for Jpake4KeyConfirmationRequest
+   - [x] Tests for Jpake4KeyConfirmationRequest
 - [x] PumpChallengeRequest
    - [ ] Tests for PumpChallengeRequest
 

--- a/Tests/TandemCoreTests/Messages/Authentication/CentralChallengeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/CentralChallengeRequestTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import TandemCore
+
+final class CentralChallengeRequestTests: XCTestCase {
+    func testTconnectAppFirstRequest() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHex = "4d08435da2694735"
+        let expected = CentralChallengeRequest(appInstanceId: 0, centralChallenge: Data(hexadecimalString: centralChallengeHex)!)
+
+        let parsed: CentralChallengeRequest = MessageTester.test(
+            "000010000a00004d08435da26947356d6f",
+            0,
+            1,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.centralChallenge, parsed.centralChallenge)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake1bRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake1bRequestTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake1bRequestTests: XCTestCase {
+    func test167cargoPumpchallengeSplit() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHex = "4104faf1c1c7737041a88872ba435c79fe67b14fd793f452b4e1a41cf4e8569ed1b67c9ab0523d97f79a536ab498d23d0d941443b319402f9406393c1c800c203cac41042dd19aad7f25eabd064b6f2ee474ac900fd61550aef781eca29b4e9fdb921a1ecd395e88cc0ee6f09c961d49e3e31d22cb178ea63ce560ebe71127521b6f7d3320303b8172c67d855dbdeeac9a32f1f067ea4924b95701563021874c2f78785e6a"
+        let expectedCargo = Data(hexadecimalString: "0000" + centralChallengeHex)!
+        let expected = Jpake1bRequest(cargo: expectedCargo)
+
+        let parsed: Jpake1bRequest = MessageTester.test(
+            "09012201a700004104faf1c1c7737041a88872ba",
+            1,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected,
+            "0801435c79fe67b14fd793f452b4e1a41cf4e856",
+            "07019ed1b67c9ab0523d97f79a536ab498d23d0d",
+            "0601941443b319402f9406393c1c800c203cac41",
+            "0501042dd19aad7f25eabd064b6f2ee474ac900f",
+            "0401d61550aef781eca29b4e9fdb921a1ecd395e",
+            "030188cc0ee6f09c961d49e3e31d22cb178ea63c",
+            "0201e560ebe71127521b6f7d3320303b8172c67d",
+            "0101855dbdeeac9a32f1f067ea4924b957015630",
+            "000121874c2f78785e6afd38"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(0, parsed.appInstanceId)
+        XCTAssertEqual(165, parsed.centralChallenge.count)
+        MessageTester.assertHexEquals(Data(hexadecimalString: centralChallengeHex)!, parsed.centralChallenge)
+    }
+
+    func testGetEccDetails() {
+        let centralChallengeV2RequestBytes = Data(hexadecimalString: "4104faf1c1c7737041a88872ba435c79fe67b14fd793f452b4e1a41cf4e8569ed1b67c9ab0523d97f79a536ab498d23d0d941443b319402f9406393c1c800c203cac41042dd19aad7f25eabd064b6f2ee474ac900fd61550aef781eca29b4e9fdb921a1ecd395e88cc0ee6f09c961d49e3e31d22cb178ea63ce560ebe71127521b6f7d3320303b8172c67d855dbdeeac9a32f1f067ea4924b95701563021874c2f78785e6a")!
+        let challengeV2ResponseBytes = Data(hexadecimalString: "4104dc82c0b7f60e601ebed41ebafac79dac6b23055d6c2949e3bd7643acd951c400ca60513dbff125da5238e0a7eee27ff4533afded0725ad2804987c90646ade0f41048177dda93af133fcfcc3a78408af82370d76af3ecfe78bc16c732310ed00b188ae0b4c2769876ac29d6c65a205c96dd518e3166aa57d61bca1a6756aabbe4f6920c472ac523abdd69e678149c128daa073861c6c9371f04254d158b6481f2226ba")!
+        let reqCurve = getCurve(centralChallengeV2RequestBytes)
+        let respCurve = getCurve(challengeV2ResponseBytes)
+        XCTAssertEqual(reqCurve.namedCurve, respCurve.namedCurve)
+        // XCTAssertEqual(reqCurve.curveId, respCurve.curveId)
+    }
+
+    private func getCurve(_ data: Data) -> (namedCurve: Int, curveId: Int) {
+        let namedCurve = Int(data[0])
+        let curveId = Int(data[1]) << 8 | Int(data[2])
+        return (namedCurve, curveId)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake2RequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake2RequestTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake2RequestTests: XCTestCase {
+    func test167cargoThirdchallengeSplit() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHex = "4104cf87b9389904510a1dc60a01b0bcfcfbcd15787aa9af7fc5ec130d29b422799cc0faeec10f0d1800052c882a4100becee73d5c98c31d264428026f23994ecfdf41040f3dbda4ba90c341c891376502823e405adf32dc3c7039d7399e1b4953a435d056fd2a1ed2a834f8f40c6215f503dd470c6862d63e2fa47c52b90e77e6cd725920f12b8b1ffadb0c65b53eba740aa751f3c59912e19a5f2e6622619797fe770c0b"
+        let expectedCargo = Data(hexadecimalString: "0000" + centralChallengeHex)!
+        let expected = Jpake2Request(cargo: expectedCargo)
+
+        let parsed: Jpake2Request = MessageTester.test(
+            "09022402a700004104cf87b9389904510a1dc60a",
+            2,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected,
+            "080201b0bcfcfbcd15787aa9af7fc5ec130d29b4",
+            "070222799cc0faeec10f0d1800052c882a4100be",
+            "0602cee73d5c98c31d264428026f23994ecfdf41",
+            "0502040f3dbda4ba90c341c891376502823e405a",
+            "0402df32dc3c7039d7399e1b4953a435d056fd2a",
+            "03021ed2a834f8f40c6215f503dd470c6862d63e",
+            "02022fa47c52b90e77e6cd725920f12b8b1ffadb",
+            "01020c65b53eba740aa751f3c59912e19a5f2e66",
+            "000222619797fe770c0b4106"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(0, parsed.appInstanceId)
+        XCTAssertEqual(165, parsed.centralChallenge.count)
+        MessageTester.assertHexEquals(Data(hexadecimalString: centralChallengeHex)!, parsed.centralChallenge)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake3SessionKeyRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake3SessionKeyRequestTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake3SessionKeyRequestTests: XCTestCase {
+    func test167cargoFourthchallengeSplit() {
+        MessageTester.initPumpState("test", 0)
+        let expected = Jpake3SessionKeyRequest(challengeParam: 0)
+
+        let parsed: Jpake3SessionKeyRequest = MessageTester.test(
+            "000326030200008121",
+            3,
+            1,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(0, parsed.challengeParam)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake4KeyConfirmationRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake4KeyConfirmationRequestTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake4KeyConfirmationRequestTests: XCTestCase {
+    func test167cargoFifthchallengeSplit() {
+        MessageTester.initPumpState("test", 0)
+        let nonce = Data(hexadecimalString: "571ad034741c777d")!
+        let reserved = Data(hexadecimalString: "0000000000000000")!
+        let hashDigest = Data(hexadecimalString: "2fece0828a91f7372a47cb7bf597a296961f66f0f45c4b7b76e9aeaf8f176f6d")!
+        let expected = Jpake4KeyConfirmationRequest(appInstanceId: 0, nonce: nonce, reserved: reserved, hashDigest: hashDigest)
+
+        let parsed: Jpake4KeyConfirmationRequest = MessageTester.test(
+            "03042804320000571ad034741c777d0000000000",
+            4,
+            4,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected,
+            "02040000002fece0828a91f7372a47cb7bf597a2",
+            "010496961f66f0f45c4b7b76e9aeaf8f176f6d44",
+            "00046e"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(0, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.hashDigest, parsed.hashDigest)
+        MessageTester.assertHexEquals(expected.reserved, parsed.reserved)
+        MessageTester.assertHexEquals(expected.nonce, parsed.nonce)
+    }
+}


### PR DESCRIPTION
## Summary
- port PumpX2 CentralChallengeRequest tests
- port PumpX2 JPake1b/2/3/4 request tests
- check off completed test items in AGENTS checklist

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d448dda0832ca9c48de5aa351650