### PR TITLE
Add ControlIQ history logs and control stream helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,10 +195,10 @@ Requests:
    - [ ] Tests for NonexistentFillCannulaStateStreamRequest
 - [x] NonexistentFillTubingStateStreamRequest
    - [ ] Tests for NonexistentFillTubingStateStreamRequest
-- [ ] NonexistentPumpingStateStreamRequest
+- [x] NonexistentPumpingStateStreamRequest
 
 Responses:
-- [ ] ControlStreamMessages
+- [x] ControlStreamMessages
 - [x] DetectingCartridgeStateStreamResponse
    - [ ] Tests for DetectingCartridgeStateStreamResponse
 - [x] EnterChangeCartridgeModeStateStreamResponse
@@ -209,7 +209,7 @@ Responses:
    - [ ] Tests for FillCannulaStateStreamResponse
 - [x] FillTubingStateStreamResponse
    - [ ] Tests for FillTubingStateStreamResponse
-- [ ] PumpingStateStreamResponse
+- [x] PumpingStateStreamResponse
 
 ### CurrentStatus
 Requests:
@@ -484,8 +484,8 @@ Responses:
 - [x] CgmCalibrationHistoryLog
 - [x] CgmDataGxHistoryLog
 - [x] CgmDataSampleHistoryLog
-- [ ] ControlIQPcmChangeHistoryLog
-- [ ] ControlIQUserModeChangeHistoryLog
+- [x] ControlIQPcmChangeHistoryLog
+- [x] ControlIQUserModeChangeHistoryLog
 - [ ] CorrectionDeclinedHistoryLog
 - [ ] DailyBasalHistoryLog
 - [ ] DataLogCorruptionHistoryLog
@@ -501,7 +501,7 @@ Responses:
 - [ ] IdpBolusHistoryLog
 - [ ] IdpListHistoryLog
 - [ ] IdpTimeDependentSegmentHistoryLog
-- [ ] LogErasedHistoryLog
+- [x] LogErasedHistoryLog
 - [ ] NewDayHistoryLog
 - [ ] ParamChangeGlobalSettingsHistoryLog
 - [ ] ParamChangePumpSettingsHistoryLog

--- a/Sources/TandemCore/Messages/ControlStream/ControlStreamMessages.swift
+++ b/Sources/TandemCore/Messages/ControlStream/ControlStreamMessages.swift
@@ -1,0 +1,42 @@
+//
+//  ControlStreamMessages.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's ControlStreamMessages.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/controlStream/ControlStreamMessages.java
+//
+import Foundation
+
+/// Utility for determining the paired request message for a control stream response.
+public enum ControlStreamMessages {
+    /// Determines which request message corresponds to a control stream response payload.
+    /// - Parameter rawBtValue: Raw Bluetooth payload including the opcode at index 2.
+    /// - Returns: A new instance of the associated request message, or `nil` if unknown.
+    public static func determineRequestMessage(rawBtValue: Data) -> Message? {
+        precondition(rawBtValue.count >= 3)
+        let opCode = rawBtValue[2]
+        switch opCode {
+        case DetectingCartridgeStateStreamResponse.props.opCode:
+            return NonexistentDetectingCartridgeStateStreamRequest()
+        case EnterChangeCartridgeModeStateStreamResponse.props.opCode:
+            return NonexistentEnterChangeCartridgeModeStateStreamRequest()
+        case FillTubingStateStreamResponse.props.opCode:
+            return NonexistentFillTubingStateStreamRequest()
+        case FillCannulaStateStreamResponse.props.opCode:
+            return NonexistentFillCannulaStateStreamRequest()
+        case UInt8(bitPattern: Int8(-23)):
+            // Both ExitFillTubingModeStateStreamResponse and PumpingStateStreamResponse use this opcode.
+            // Distinguish by payload length: PumpingStateStreamResponse has additional padding bytes.
+            if rawBtValue.count >= 29 {
+                return NonexistentPumpingStateStreamRequest()
+            } else {
+                return NonexistentExitFillTubingModeStateStreamRequest()
+            }
+        default:
+            return nil
+        }
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ControlIQPcmChangeHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ControlIQPcmChangeHistoryLog.swift
@@ -1,0 +1,45 @@
+//
+//  ControlIQPcmChangeHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's ControlIQPcmChangeHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQPcmChangeHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating a ControlIQ Pump Control Mode (PCM) change.
+public class ControlIQPcmChangeHistoryLog: HistoryLog {
+    public static let typeId = 230
+
+    public let currentPcm: Int
+    public let previousPcm: Int
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.currentPcm = Int(raw[10])
+        self.previousPcm = Int(raw[11])
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, currentPcm: Int, previousPcm: Int) {
+        let payload = ControlIQPcmChangeHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, currentPcm: currentPcm, previousPcm: previousPcm)
+        self.currentPcm = currentPcm
+        self.previousPcm = previousPcm
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, currentPcm: Int, previousPcm: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(bitPattern: Int8(-26)), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(currentPcm & 0xFF)]),
+                Data([UInt8(previousPcm & 0xFF)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ControlIQUserModeChangeHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ControlIQUserModeChangeHistoryLog.swift
@@ -1,0 +1,45 @@
+//
+//  ControlIQUserModeChangeHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's ControlIQUserModeChangeHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ControlIQUserModeChangeHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating a ControlIQ user mode change.
+public class ControlIQUserModeChangeHistoryLog: HistoryLog {
+    public static let typeId = 229
+
+    public let currentUserMode: Int
+    public let previousUserMode: Int
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.currentUserMode = Int(raw[10])
+        self.previousUserMode = Int(raw[11])
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, currentUserMode: Int, previousUserMode: Int) {
+        let payload = ControlIQUserModeChangeHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, currentUserMode: currentUserMode, previousUserMode: previousUserMode)
+        self.currentUserMode = currentUserMode
+        self.previousUserMode = previousUserMode
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, currentUserMode: Int, previousUserMode: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(bitPattern: Int8(-27)), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(currentUserMode & 0xFF)]),
+                Data([UInt8(previousUserMode & 0xFF)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/LogErasedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/LogErasedHistoryLog.swift
@@ -1,0 +1,42 @@
+//
+//  LogErasedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  Swift representation of PumpX2's LogErasedHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/LogErasedHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating a segment of log entries was erased.
+public class LogErasedHistoryLog: HistoryLog {
+    public static let typeId = 0
+
+    /// Number of entries erased from the pump history.
+    public let numErased: UInt32
+
+    public required init(cargo: Data) {
+        let raw = HistoryLog.fillCargo(cargo)
+        self.numErased = Bytes.readUint32(raw, 10)
+        super.init(cargo: raw)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, numErased: UInt32) {
+        let payload = LogErasedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, numErased: numErased)
+        self.numErased = numErased
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, numErased: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([0, 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(numErased)
+            )
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- port ControlIQ PCM and user mode change history logs to Swift
- add helper for mapping control stream responses to their requests
- implement LogErasedHistoryLog and update message checklist

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d63f1f30832c9279ba131936962d