### PR TITLE
Port additional history logs from PumpX2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,33 +486,33 @@ Responses:
 - [x] CgmDataSampleHistoryLog
 - [x] ControlIQPcmChangeHistoryLog
 - [x] ControlIQUserModeChangeHistoryLog
-- [ ] CorrectionDeclinedHistoryLog
-- [ ] DailyBasalHistoryLog
-- [ ] DataLogCorruptionHistoryLog
-- [ ] DateChangeHistoryLog
-- [ ] FactoryResetHistoryLog
+- [x] CorrectionDeclinedHistoryLog
+- [x] DailyBasalHistoryLog
+- [x] DataLogCorruptionHistoryLog
+- [x] DateChangeHistoryLog
+- [x] FactoryResetHistoryLog
 - [x] HistoryLog
 - [x] HistoryLogParser
 - [x] HistoryLogStreamResponse
-- [ ] HypoMinimizerResumeHistoryLog
-- [ ] HypoMinimizerSuspendHistoryLog
+- [x] HypoMinimizerResumeHistoryLog
+- [x] HypoMinimizerSuspendHistoryLog
 - [ ] IdpActionHistoryLog
 - [ ] IdpActionMsg2HistoryLog
 - [ ] IdpBolusHistoryLog
 - [ ] IdpListHistoryLog
 - [ ] IdpTimeDependentSegmentHistoryLog
 - [x] LogErasedHistoryLog
-- [ ] NewDayHistoryLog
+- [x] NewDayHistoryLog
 - [ ] ParamChangeGlobalSettingsHistoryLog
 - [ ] ParamChangePumpSettingsHistoryLog
 - [ ] ParamChangeRemSettingsHistoryLog
 - [ ] ParamChangeReminderHistoryLog
 - [x] PumpingResumedHistoryLog
 - [x] PumpingSuspendedHistoryLog
-- [ ] TempRateActivatedHistoryLog
-- [ ] TempRateCompletedHistoryLog
-- [ ] TimeChangedHistoryLog
-- [ ] TubingFilledHistoryLog
+- [x] TempRateActivatedHistoryLog
+- [x] TempRateCompletedHistoryLog
+- [x] TimeChangedHistoryLog
+- [x] TubingFilledHistoryLog
 - [x] UnknownHistoryLog
 - [x] UsbConnectedHistoryLog
 - [x] UsbDisconnectedHistoryLog

--- a/Sources/TandemCore/Messages/HistoryLog/CorrectionDeclinedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/CorrectionDeclinedHistoryLog.swift
@@ -1,0 +1,55 @@
+//
+//  CorrectionDeclinedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's CorrectionDeclinedHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/CorrectionDeclinedHistoryLog.java
+//
+import Foundation
+
+/// History log entry for a declined correction bolus.
+public class CorrectionDeclinedHistoryLog: HistoryLog {
+    public static let typeId = 93
+
+    public let bg: Int
+    public let bolusId: Int
+    public let iob: Float
+    public let targetBg: Int
+    public let isf: Int
+
+    public required init(cargo: Data) {
+        self.bg = Bytes.readShort(cargo, 10)
+        self.bolusId = Bytes.readShort(cargo, 12)
+        self.iob = Bytes.readFloat(cargo, 14)
+        self.targetBg = Bytes.readShort(cargo, 18)
+        self.isf = Bytes.readShort(cargo, 20)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, bg: Int, bolusId: Int, iob: Float, targetBg: Int, isf: Int) {
+        let payload = CorrectionDeclinedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, bg: bg, bolusId: bolusId, iob: iob, targetBg: targetBg, isf: isf)
+        self.bg = bg
+        self.bolusId = bolusId
+        self.iob = iob
+        self.targetBg = targetBg
+        self.isf = isf
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, bg: Int, bolusId: Int, iob: Float, targetBg: Int, isf: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(bg),
+                Bytes.firstTwoBytesLittleEndian(bolusId),
+                Bytes.toFloat(iob),
+                Bytes.firstTwoBytesLittleEndian(targetBg),
+                Bytes.firstTwoBytesLittleEndian(isf)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/DailyBasalHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/DailyBasalHistoryLog.swift
@@ -1,0 +1,59 @@
+//
+//  DailyBasalHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's DailyBasalHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DailyBasalHistoryLog.java
+//
+import Foundation
+
+/// History log entry summarizing daily basal delivery.
+public class DailyBasalHistoryLog: HistoryLog {
+    public static let typeId = 81
+
+    public let dailyTotalBasal: Float
+    public let lastBasalRate: Float
+    public let iob: Float
+    public let finalEventForDay: Bool
+    public let batteryChargeRaw: Int
+    public let lipoMv: Int
+
+    public required init(cargo: Data) {
+        self.dailyTotalBasal = Bytes.readFloat(cargo, 10)
+        self.lastBasalRate = Bytes.readFloat(cargo, 14)
+        self.iob = Bytes.readFloat(cargo, 18)
+        self.finalEventForDay = cargo[22] == 1
+        self.batteryChargeRaw = Int(cargo[23])
+        self.lipoMv = Bytes.readShort(cargo, 24)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, dailyTotalBasal: Float, lastBasalRate: Float, iob: Float, finalEventForDay: Bool, batteryChargeRaw: Int, lipoMv: Int) {
+        let payload = DailyBasalHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, dailyTotalBasal: dailyTotalBasal, lastBasalRate: lastBasalRate, iob: iob, finalEventForDay: finalEventForDay, batteryChargeRaw: batteryChargeRaw, lipoMv: lipoMv)
+        self.dailyTotalBasal = dailyTotalBasal
+        self.lastBasalRate = lastBasalRate
+        self.iob = iob
+        self.finalEventForDay = finalEventForDay
+        self.batteryChargeRaw = batteryChargeRaw
+        self.lipoMv = lipoMv
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, dailyTotalBasal: Float, lastBasalRate: Float, iob: Float, finalEventForDay: Bool, batteryChargeRaw: Int, lipoMv: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(dailyTotalBasal),
+                Bytes.toFloat(lastBasalRate),
+                Bytes.toFloat(iob),
+                Data([finalEventForDay ? 1 : 0]),
+                Data([UInt8(batteryChargeRaw & 0xFF)]),
+                Bytes.firstTwoBytesLittleEndian(lipoMv)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/DataLogCorruptionHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/DataLogCorruptionHistoryLog.swift
@@ -1,0 +1,34 @@
+//
+//  DataLogCorruptionHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's DataLogCorruptionHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DataLogCorruptionHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating data log corruption.
+public class DataLogCorruptionHistoryLog: HistoryLog {
+    public static let typeId = 60
+
+    public required init(cargo: Data) {
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32) {
+        let payload = DataLogCorruptionHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum)
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/DateChangeHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/DateChangeHistoryLog.swift
@@ -1,0 +1,48 @@
+//
+//  DateChangeHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's DateChangeHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/DateChangeHistoryLog.java
+//
+import Foundation
+
+/// History log entry recording a change in the pump's date.
+public class DateChangeHistoryLog: HistoryLog {
+    public static let typeId = 14
+
+    public let datePrior: UInt32
+    public let dateAfter: UInt32
+    public let rawRTCTime: UInt32
+
+    public required init(cargo: Data) {
+        self.datePrior = Bytes.readUint32(cargo, 10)
+        self.dateAfter = Bytes.readUint32(cargo, 14)
+        self.rawRTCTime = Bytes.readUint32(cargo, 18)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, datePrior: UInt32, dateAfter: UInt32, rawRTCTime: UInt32) {
+        let payload = DateChangeHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, datePrior: datePrior, dateAfter: dateAfter, rawRTCTime: rawRTCTime)
+        self.datePrior = datePrior
+        self.dateAfter = dateAfter
+        self.rawRTCTime = rawRTCTime
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, datePrior: UInt32, dateAfter: UInt32, rawRTCTime: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(datePrior),
+                Bytes.toUint32(dateAfter),
+                Bytes.toUint32(rawRTCTime),
+                Data(count: 4)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/FactoryResetHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/FactoryResetHistoryLog.swift
@@ -1,0 +1,34 @@
+//
+//  FactoryResetHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's FactoryResetHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/FactoryResetHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating a factory reset occurred.
+public class FactoryResetHistoryLog: HistoryLog {
+    public static let typeId = 82
+
+    public required init(cargo: Data) {
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32) {
+        let payload = FactoryResetHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum)
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
@@ -34,6 +34,30 @@ public enum HistoryLogParser {
             return CgmDataSampleHistoryLog(cargo: raw)
         case CgmDataGxHistoryLog.typeId:
             return CgmDataGxHistoryLog(cargo: raw)
+        case CorrectionDeclinedHistoryLog.typeId:
+            return CorrectionDeclinedHistoryLog(cargo: raw)
+        case DailyBasalHistoryLog.typeId:
+            return DailyBasalHistoryLog(cargo: raw)
+        case DataLogCorruptionHistoryLog.typeId:
+            return DataLogCorruptionHistoryLog(cargo: raw)
+        case DateChangeHistoryLog.typeId:
+            return DateChangeHistoryLog(cargo: raw)
+        case FactoryResetHistoryLog.typeId:
+            return FactoryResetHistoryLog(cargo: raw)
+        case HypoMinimizerResumeHistoryLog.typeId:
+            return HypoMinimizerResumeHistoryLog(cargo: raw)
+        case HypoMinimizerSuspendHistoryLog.typeId:
+            return HypoMinimizerSuspendHistoryLog(cargo: raw)
+        case NewDayHistoryLog.typeId:
+            return NewDayHistoryLog(cargo: raw)
+        case TempRateActivatedHistoryLog.typeId:
+            return TempRateActivatedHistoryLog(cargo: raw)
+        case TempRateCompletedHistoryLog.typeId:
+            return TempRateCompletedHistoryLog(cargo: raw)
+        case TimeChangedHistoryLog.typeId:
+            return TimeChangedHistoryLog(cargo: raw)
+        case TubingFilledHistoryLog.typeId:
+            return TubingFilledHistoryLog(cargo: raw)
         case PumpingSuspendedHistoryLog.typeId:
             return PumpingSuspendedHistoryLog(cargo: raw)
         case PumpingResumedHistoryLog.typeId:

--- a/Sources/TandemCore/Messages/HistoryLog/HypoMinimizerResumeHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HypoMinimizerResumeHistoryLog.swift
@@ -1,0 +1,39 @@
+//
+//  HypoMinimizerResumeHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's HypoMinimizerResumeHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerResumeHistoryLog.java
+//
+import Foundation
+
+/// History log entry for Hypo Minimizer resume events.
+public class HypoMinimizerResumeHistoryLog: HistoryLog {
+    public static let typeId = 199
+
+    public let reason: UInt32
+
+    public required init(cargo: Data) {
+        self.reason = Bytes.readUint32(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, reason: UInt32) {
+        let payload = HypoMinimizerResumeHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, reason: reason)
+        self.reason = reason
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, reason: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(reason)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/HypoMinimizerSuspendHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HypoMinimizerSuspendHistoryLog.swift
@@ -1,0 +1,34 @@
+//
+//  HypoMinimizerSuspendHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's HypoMinimizerSuspendHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/HypoMinimizerSuspendHistoryLog.java
+//
+import Foundation
+
+/// History log entry for Hypo Minimizer suspend events.
+public class HypoMinimizerSuspendHistoryLog: HistoryLog {
+    public static let typeId = 198
+
+    public required init(cargo: Data) {
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32) {
+        let payload = HypoMinimizerSuspendHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum)
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/NewDayHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/NewDayHistoryLog.swift
@@ -1,0 +1,39 @@
+//
+//  NewDayHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's NewDayHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/NewDayHistoryLog.java
+//
+import Foundation
+
+/// History log entry marking the start of a new day.
+public class NewDayHistoryLog: HistoryLog {
+    public static let typeId = 90
+
+    public let commandedBasalRate: Float
+
+    public required init(cargo: Data) {
+        self.commandedBasalRate = Bytes.readFloat(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, commandedBasalRate: Float) {
+        let payload = NewDayHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, commandedBasalRate: commandedBasalRate)
+        self.commandedBasalRate = commandedBasalRate
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, commandedBasalRate: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(commandedBasalRate)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/TempRateActivatedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/TempRateActivatedHistoryLog.swift
@@ -1,0 +1,47 @@
+//
+//  TempRateActivatedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's TempRateActivatedHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateActivatedHistoryLog.java
+//
+import Foundation
+
+/// History log entry for activation of a temporary basal rate.
+public class TempRateActivatedHistoryLog: HistoryLog {
+    public static let typeId = 2
+
+    public let percent: Float
+    public let duration: Float
+    public let tempRateId: Int
+
+    public required init(cargo: Data) {
+        self.percent = Bytes.readFloat(cargo, 10)
+        self.duration = Bytes.readFloat(cargo, 14)
+        self.tempRateId = Bytes.readShort(cargo, 20)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, percent: Float, duration: Float, tempRateId: Int) {
+        let payload = TempRateActivatedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, percent: percent, duration: duration, tempRateId: tempRateId)
+        self.percent = percent
+        self.duration = duration
+        self.tempRateId = tempRateId
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, percent: Float, duration: Float, tempRateId: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(percent),
+                Bytes.toFloat(duration),
+                Bytes.firstTwoBytesLittleEndian(tempRateId)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/TempRateCompletedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/TempRateCompletedHistoryLog.swift
@@ -1,0 +1,43 @@
+//
+//  TempRateCompletedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's TempRateCompletedHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TempRateCompletedHistoryLog.java
+//
+import Foundation
+
+/// History log entry for completion of a temporary basal rate.
+public class TempRateCompletedHistoryLog: HistoryLog {
+    public static let typeId = 15
+
+    public let tempRateId: Int
+    public let timeLeft: UInt32
+
+    public required init(cargo: Data) {
+        self.tempRateId = Bytes.readShort(cargo, 12)
+        self.timeLeft = Bytes.readUint32(cargo, 14)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, tempRateId: Int, timeLeft: UInt32) {
+        let payload = TempRateCompletedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, tempRateId: tempRateId, timeLeft: timeLeft)
+        self.tempRateId = tempRateId
+        self.timeLeft = timeLeft
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, tempRateId: Int, timeLeft: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.firstTwoBytesLittleEndian(tempRateId),
+                Bytes.toUint32(timeLeft)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/TimeChangedHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/TimeChangedHistoryLog.swift
@@ -1,0 +1,47 @@
+//
+//  TimeChangedHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's TimeChangedHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TimeChangedHistoryLog.java
+//
+import Foundation
+
+/// History log entry recording a change in the pump's time.
+public class TimeChangedHistoryLog: HistoryLog {
+    public static let typeId = 13
+
+    public let timePrior: UInt32
+    public let timeAfter: UInt32
+    public let rawRTC: UInt32
+
+    public required init(cargo: Data) {
+        self.timePrior = Bytes.readUint32(cargo, 10)
+        self.timeAfter = Bytes.readUint32(cargo, 14)
+        self.rawRTC = Bytes.readUint32(cargo, 18)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, timePrior: UInt32, timeAfter: UInt32, rawRTC: UInt32) {
+        let payload = TimeChangedHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, timePrior: timePrior, timeAfter: timeAfter, rawRTC: rawRTC)
+        self.timePrior = timePrior
+        self.timeAfter = timeAfter
+        self.rawRTC = rawRTC
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, timePrior: UInt32, timeAfter: UInt32, rawRTC: UInt32) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toUint32(timePrior),
+                Bytes.toUint32(timeAfter),
+                Bytes.toUint32(rawRTC)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/TubingFilledHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/TubingFilledHistoryLog.swift
@@ -1,0 +1,39 @@
+//
+//  TubingFilledHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//  Migrated from PumpX2's TubingFilledHistoryLog.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/TubingFilledHistoryLog.java
+//
+import Foundation
+
+/// History log entry indicating the pump's tubing was filled.
+public class TubingFilledHistoryLog: HistoryLog {
+    public static let typeId = 63
+
+    public let primeSize: Float
+
+    public required init(cargo: Data) {
+        self.primeSize = Bytes.readFloat(cargo, 10)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, primeSize: Float) {
+        let payload = TubingFilledHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, primeSize: primeSize)
+        self.primeSize = primeSize
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, primeSize: Float) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId & 0xFF), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Bytes.toFloat(primeSize)
+            )
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Swift ports for multiple history log records not yet implemented
- wire new logs into `HistoryLogParser`
- mark completed logs in `AGENTS.md`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d9382b10832c9be1c3a2583cfeb2