### PR TITLE
Add authentication message tests from PumpX2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,18 +17,18 @@ Requests:
 - [x] Jpake4KeyConfirmationRequest
    - [x] Tests for Jpake4KeyConfirmationRequest
 - [x] PumpChallengeRequest
-   - [ ] Tests for PumpChallengeRequest
+   - [x] Tests for PumpChallengeRequest
 
 Responses:
 - [x] AbstractCentralChallengeResponse
    - [ ] Tests for AbstractCentralChallengeResponse
 - [x] AbstractPumpChallengeResponse
 - [x] CentralChallengeResponse
-   - [ ] Tests for CentralChallengeResponse
+   - [x] Tests for CentralChallengeResponse
 - [x] Jpake1aResponse
-   - [ ] Tests for Jpake1aResponse
+   - [x] Tests for Jpake1aResponse
 - [x] Jpake1bResponse
-   - [ ] Tests for Jpake1bResponse
+   - [x] Tests for Jpake1bResponse
 - [x] Jpake2Response
    - [ ] Tests for Jpake2Response
 - [x] Jpake3SessionKeyResponse

--- a/Tests/TandemCoreTests/Messages/Authentication/CentralChallengeResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/CentralChallengeResponseTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import TandemCore
+
+final class CentralChallengeResponseTests: XCTestCase {
+    func testTconnectAppFirstPumpReplyMessage_legacyAuth() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHash = Data(hexadecimalString: "8c212d7a8fbda85f83a3440254488dfb561264ec")!
+        let hmacKey = Data(hexadecimalString: "840c4e16873046bc")!
+        let expected = CentralChallengeResponse(appInstanceId: 1, centralChallengeHash: centralChallengeHash, hmacKey: hmacKey)
+
+        let parsed: CentralChallengeResponse = MessageTester.test(
+            "000011001e01008c212d7a8fbda85f83a3440254488dfb561264ec840c4e16873046bc2c1a",
+            0,
+            2,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.centralChallengeHash, parsed.centralChallengeHash)
+        MessageTester.assertHexEquals(expected.hmacKey, parsed.hmacKey)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake1aResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake1aResponseTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake1aResponseTests: XCTestCase {
+    func test167cargoResponseSplit() {
+        MessageTester.initPumpState("test", 0)
+        let expected = Jpake1aResponse(cargo: Data(hexadecimalString: "000041048139ce7f5012e2c32c8be4a3eb4511f9bd1c471bed0f1ccf623a2a0399e4f7de35e00c2ae0d8b42d173183ed624b276caf83bb68ce665f1acab03b758056dbca41047a0e04939c0089e44de6268e0018c390c5fb1d4d832a52fd67dcd003d31fd576ff3eb7a838d0b389a0d2544fc740119aced931ac6385ab8ca620e0756d17f5fb20b570ea8e5460cc45b1b733c2edb2bc32a206f1aab956da044e01ba1be6d09913")!)
+
+        let parsed: Jpake1aResponse = MessageTester.test(
+            "00002100a7000041048139ce7f5012e2c32c8be4a3eb4511f9bd1c471bed0f1ccf623a2a0399e4f7de35e00c2ae0d8b42d173183ed624b276caf83bb68ce665f1acab03b758056dbca41047a0e04939c0089e44de6268e0018c390c5fb1d4d832a52fd67dcd003d31fd576ff3eb7a838d0b389a0d2544fc740119aced931ac6385ab8ca620e0756d17f5fb20b570ea8e5460cc45b1b733c2edb2bc32a206f1aab956da044e01ba1be6d099132562",
+            0,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testOneoffResponse() {
+        MessageTester.initPumpState("test", 0)
+        let expected = Jpake1aResponse(cargo: Data(hexadecimalString: "0100410441e099e06fda4ba1ea6b6e727e4790fee1303018a97a8a1eed5093f2dab4cbced4ac1f392fbff14a89cc7b8ee06fdadd09d4b67222e1af69612ae3b727679ae94104c9dd154dd328e468cda64f39d6c5e5dfc6645fa60883cee41ca536d22fd6f5ddf12ed045c8eff2edf59f13249268cf403e19585711e8393872954632e896fbb820a8c41909ae5120fa17fc0716ca65dc5fb440e94b78ce9c82c997a0fc4f855d41")!)
+
+        let parsed: Jpake1aResponse = MessageTester.test(
+            "00002100a70100410441e099e06fda4ba1ea6b6e727e4790fee1303018a97a8a1eed5093f2dab4cbced4ac1f392fbff14a89cc7b8ee06fdadd09d4b67222e1af69612ae3b727679ae94104c9dd154dd328e468cda64f39d6c5e5dfc6645fa60883cee41ca536d22fd6f5ddf12ed045c8eff2edf59f13249268cf403e19585711e8393872954632e896fbb820a8c41909ae5120fa17fc0716ca65dc5fb440e94b78ce9c82c997a0fc4f855d416119",
+            0,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake1bResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake1bResponseTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake1bResponseTests: XCTestCase {
+    func test167cargoResponseSplit() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHash = Data(hexadecimalString: "4104dc82c0b7f60e601ebed41ebafac79dac6b23055d6c2949e3bd7643acd951c400ca60513dbff125da5238e0a7eee27ff4533afded0725ad2804987c90646ade0f41048177dda93af133fcfcc3a78408af82370d76af3ecfe78bc16c732310ed00b188ae0b4c2769876ac29d6c65a205c96dd518e3166aa57d61bca1a6756aabbe4f6920c472ac523abdd69e678149c128daa073861c6c9371f04254d158b6481f2226ba")!
+        let expected = Jpake1bResponse(appInstanceId: 0, centralChallengeHash: centralChallengeHash)
+
+        let parsed: Jpake1bResponse = MessageTester.test(
+            "00012301a700004104dc82c0b7f60e601ebed41ebafac79dac6b23055d6c2949e3bd7643acd951c400ca60513dbff125da5238e0a7eee27ff4533afded0725ad2804987c90646ade0f41048177dda93af133fcfcc3a78408af82370d76af3ecfe78bc16c732310ed00b188ae0b4c2769876ac29d6c65a205c96dd518e3166aa57d61bca1a6756aabbe4f6920c472ac523abdd69e678149c128daa073861c6c9371f04254d158b6481f2226ba3927",
+            1,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        MessageTester.assertHexEquals(expected.centralChallengeHash, parsed.centralChallengeHash)
+        MessageTester.assertHexEquals(Data(hexadecimalString: "4104dc82c0b7f60e601ebed41ebafac79dac6b23055d6c2949e3bd7643acd951c400ca60513dbff125da5238e0a7eee27ff4533afded0725ad2804987c90646ade0f41048177dda93af133fcfcc3a78408af82370d76af3ecfe78bc16c732310ed00b188ae0b4c2769876ac29d6c65a205c96dd518e3166aa57d61bca1a6756aabbe4f6920c472ac523abdd69e678149c128daa073861c6c9371f04254d158b6481f2226ba")!, parsed.centralChallengeHash)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/PumpChallengeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/PumpChallengeRequestTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import TandemCore
+
+final class PumpChallengeRequestTests: XCTestCase {
+    func testTconnectAppPumpChallengeRequest() {
+        MessageTester.initPumpState("test", 0)
+        let pumpChallengeHash = Data(hexadecimalString: "0194a8f98ca49cddf70c2c1331730290bca3df07")!
+        let expected = PumpChallengeRequest(appInstanceId: 1, pumpChallengeHash: pumpChallengeHash)
+
+        let parsed: PumpChallengeRequest = MessageTester.test(
+            "010112011601000194a8f98ca49cddf70c2c1331",
+            1,
+            2,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected,
+            "0001730290bca3df079967"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.pumpChallengeHash, parsed.pumpChallengeHash)
+    }
+}

--- a/Tests/TandemCoreTests/PumpChallengeRequestBuilderTests.swift
+++ b/Tests/TandemCoreTests/PumpChallengeRequestBuilderTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import TandemCore
+
+final class PumpChallengeRequestBuilderTests: XCTestCase {
+    func testValidLongCode() {
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("abcdefghijklmnop"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("abcd-efgh-ijkl-mnop"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("abcd-1234-ijkl-5678"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("abcd1234ijkl5678"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("abcd-1234-ijkl 5678"))
+    }
+
+    func testInvalidLongCode1() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("abcd-!fgh-ijkl-mnop")) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidLongPairingCodeFormat)
+        }
+    }
+
+    func testInvalidLongCode2() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("abcd!fghijklmnop")) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidLongPairingCodeFormat)
+        }
+    }
+
+    func testInvalidLongCode3() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("abcd--efgh-ijkl-mnop-q")) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidLongPairingCodeFormat)
+        }
+    }
+
+    func testInvalidLongCodeIsShortCode() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("123456", type: .long16Char)) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidLongPairingCodeFormat)
+        }
+    }
+
+    func testValidShortCode() {
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("123456"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("123 456"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("123-456"))
+        XCTAssertNoThrow(try PumpChallengeRequestBuilder.processPairingCode("123-789"))
+    }
+
+    func testInvalidShortCode1() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("123", type: .short6Char)) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidShortPairingCodeFormat)
+        }
+    }
+
+    func testInvalidShortCode2() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("1234567", type: .short6Char)) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidShortPairingCodeFormat)
+        }
+    }
+
+    func testInvalidShortCode3() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("123 45a", type: .short6Char)) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidShortPairingCodeFormat)
+        }
+    }
+
+    func testInvalidShortCodeIsLongCode() {
+        XCTAssertThrowsError(try PumpChallengeRequestBuilder.processPairingCode("abcd-efgh-ijkl-mnop", type: .short6Char)) { error in
+            XCTAssertTrue(error is PumpChallengeRequestBuilder.InvalidShortPairingCodeFormat)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add PumpChallengeRequest tests and builder validation
- Port CentralChallengeResponse, Jpake1aResponse, and Jpake1bResponse tests
- Update AGENTS checklist for migrated authentication tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d93fff24832cb4d55fd976108cf4