### PR TITLE
Add missing history log types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,7 +377,7 @@ Responses:
    - [ ] Tests for ControlIQSleepScheduleResponse
 - [x] CurrentBasalStatusResponse
    - [ ] Tests for CurrentBasalStatusResponse
-- [ ] CurrentBatteryAbstractResponse
+- [x] CurrentBatteryAbstractResponse
 - [x] CurrentBatteryV1Response
    - [ ] Tests for CurrentBatteryV1Response
 - [x] CurrentBatteryV2Response
@@ -496,17 +496,17 @@ Responses:
 - [x] HistoryLogStreamResponse
 - [x] HypoMinimizerResumeHistoryLog
 - [x] HypoMinimizerSuspendHistoryLog
-- [ ] IdpActionHistoryLog
-- [ ] IdpActionMsg2HistoryLog
-- [ ] IdpBolusHistoryLog
-- [ ] IdpListHistoryLog
-- [ ] IdpTimeDependentSegmentHistoryLog
+- [x] IdpActionHistoryLog
+- [x] IdpActionMsg2HistoryLog
+- [x] IdpBolusHistoryLog
+- [x] IdpListHistoryLog
+- [x] IdpTimeDependentSegmentHistoryLog
 - [x] LogErasedHistoryLog
 - [x] NewDayHistoryLog
-- [ ] ParamChangeGlobalSettingsHistoryLog
-- [ ] ParamChangePumpSettingsHistoryLog
-- [ ] ParamChangeRemSettingsHistoryLog
-- [ ] ParamChangeReminderHistoryLog
+- [x] ParamChangeGlobalSettingsHistoryLog
+- [x] ParamChangePumpSettingsHistoryLog
+- [x] ParamChangeRemSettingsHistoryLog
+- [x] ParamChangeReminderHistoryLog
 - [x] PumpingResumedHistoryLog
 - [x] PumpingSuspendedHistoryLog
 - [x] TempRateActivatedHistoryLog

--- a/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/HistoryLogParser.swift
@@ -62,6 +62,24 @@ public enum HistoryLogParser {
             return PumpingSuspendedHistoryLog(cargo: raw)
         case PumpingResumedHistoryLog.typeId:
             return PumpingResumedHistoryLog(cargo: raw)
+        case IdpActionHistoryLog.typeId:
+            return IdpActionHistoryLog(cargo: raw)
+        case IdpActionMsg2HistoryLog.typeId:
+            return IdpActionMsg2HistoryLog(cargo: raw)
+        case IdpBolusHistoryLog.typeId:
+            return IdpBolusHistoryLog(cargo: raw)
+        case IdpListHistoryLog.typeId:
+            return IdpListHistoryLog(cargo: raw)
+        case IdpTimeDependentSegmentHistoryLog.typeId:
+            return IdpTimeDependentSegmentHistoryLog(cargo: raw)
+        case ParamChangeGlobalSettingsHistoryLog.typeId:
+            return ParamChangeGlobalSettingsHistoryLog(cargo: raw)
+        case ParamChangePumpSettingsHistoryLog.typeId:
+            return ParamChangePumpSettingsHistoryLog(cargo: raw)
+        case ParamChangeRemSettingsHistoryLog.typeId:
+            return ParamChangeRemSettingsHistoryLog(cargo: raw)
+        case ParamChangeReminderHistoryLog.typeId:
+            return ParamChangeReminderHistoryLog(cargo: raw)
         default:
             return UnknownHistoryLog(cargo: raw)
         }

--- a/Sources/TandemCore/Messages/HistoryLog/IdpActionHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/IdpActionHistoryLog.swift
@@ -1,0 +1,51 @@
+//
+//  IdpActionHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for Personal Profile (IDP) Action 1/2.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionHistoryLog.java
+//
+import Foundation
+
+public class IdpActionHistoryLog: HistoryLog {
+    public static let typeId = 69
+
+    public let idp: Int
+    public let status: Int
+    public let sourceIdp: Int
+    public let name: String
+
+    public required init(cargo: Data) {
+        self.idp = Int(cargo[10])
+        self.status = Int(cargo[11])
+        self.sourceIdp = Int(cargo[12])
+        self.name = Bytes.readString(cargo, 18, 8)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, status: Int, sourceIdp: Int, name: String) {
+        let payload = IdpActionHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, idp: idp, status: status, sourceIdp: sourceIdp, name: name)
+        self.idp = idp
+        self.status = status
+        self.sourceIdp = sourceIdp
+        self.name = name
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, status: Int, sourceIdp: Int, name: String) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: idp)]),
+                Data([UInt8(truncatingIfNeeded: status)]),
+                Data([UInt8(truncatingIfNeeded: sourceIdp)]),
+                Bytes.writeString(name, 8)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/IdpActionMsg2HistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/IdpActionMsg2HistoryLog.swift
@@ -1,0 +1,43 @@
+//
+//  IdpActionMsg2HistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for Personal Profile (IDP) Action 2/2.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpActionMsg2HistoryLog.java
+//
+import Foundation
+
+public class IdpActionMsg2HistoryLog: HistoryLog {
+    public static let typeId = 57
+
+    public let idp: Int
+    public let name: String
+
+    public required init(cargo: Data) {
+        self.idp = Int(cargo[10])
+        self.name = Bytes.readString(cargo, 18, 8)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, name: String) {
+        let payload = IdpActionMsg2HistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, idp: idp, name: name)
+        self.idp = idp
+        self.name = name
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, name: String) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: idp)]),
+                Bytes.writeString(name, 8)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/IdpBolusHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/IdpBolusHistoryLog.swift
@@ -1,0 +1,59 @@
+//
+//  IdpBolusHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for Personal Profile (IDP) Bolus Data Change.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpBolusHistoryLog.java
+//
+import Foundation
+
+public class IdpBolusHistoryLog: HistoryLog {
+    public static let typeId = 70
+
+    public let idp: Int
+    public let modification: Int
+    public let bolusStatus: Int
+    public let insulinDuration: Int
+    public let maxBolusSize: Int
+    public let bolusEntryType: Int
+
+    public required init(cargo: Data) {
+        self.idp = Int(cargo[10])
+        self.modification = Int(cargo[11])
+        self.bolusStatus = Int(cargo[12])
+        self.insulinDuration = Bytes.readShort(cargo, 14)
+        self.maxBolusSize = Bytes.readShort(cargo, 16)
+        self.bolusEntryType = Int(cargo[18])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, modification: Int, bolusStatus: Int, insulinDuration: Int, maxBolusSize: Int, bolusEntryType: Int) {
+        let payload = IdpBolusHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, idp: idp, modification: modification, bolusStatus: bolusStatus, insulinDuration: insulinDuration, maxBolusSize: maxBolusSize, bolusEntryType: bolusEntryType)
+        self.idp = idp
+        self.modification = modification
+        self.bolusStatus = bolusStatus
+        self.insulinDuration = insulinDuration
+        self.maxBolusSize = maxBolusSize
+        self.bolusEntryType = bolusEntryType
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, modification: Int, bolusStatus: Int, insulinDuration: Int, maxBolusSize: Int, bolusEntryType: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: idp)]),
+                Data([UInt8(truncatingIfNeeded: modification)]),
+                Data([UInt8(truncatingIfNeeded: bolusStatus)]),
+                Bytes.firstTwoBytesLittleEndian(insulinDuration),
+                Bytes.firstTwoBytesLittleEndian(maxBolusSize),
+                Data([UInt8(truncatingIfNeeded: bolusEntryType)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/IdpListHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/IdpListHistoryLog.swift
@@ -1,0 +1,63 @@
+//
+//  IdpListHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for Personal Profile (IDP) List.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpListHistoryLog.java
+//
+import Foundation
+
+public class IdpListHistoryLog: HistoryLog {
+    public static let typeId = 71
+
+    public let numProfiles: Int
+    public let slot1: Int
+    public let slot2: Int
+    public let slot3: Int
+    public let slot4: Int
+    public let slot5: Int
+    public let slot6: Int
+
+    public required init(cargo: Data) {
+        self.numProfiles = Int(cargo[10])
+        self.slot1 = Int(cargo[14])
+        self.slot2 = Int(cargo[15])
+        self.slot3 = Int(cargo[16])
+        self.slot4 = Int(cargo[17])
+        self.slot5 = Int(cargo[18])
+        self.slot6 = Int(cargo[19])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, numProfiles: Int, slot1: Int, slot2: Int, slot3: Int, slot4: Int, slot5: Int, slot6: Int) {
+        let payload = IdpListHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, numProfiles: numProfiles, slot1: slot1, slot2: slot2, slot3: slot3, slot4: slot4, slot5: slot5, slot6: slot6)
+        self.numProfiles = numProfiles
+        self.slot1 = slot1
+        self.slot2 = slot2
+        self.slot3 = slot3
+        self.slot4 = slot4
+        self.slot5 = slot5
+        self.slot6 = slot6
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, numProfiles: Int, slot1: Int, slot2: Int, slot3: Int, slot4: Int, slot5: Int, slot6: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: numProfiles)]),
+                Data([UInt8(truncatingIfNeeded: slot1)]),
+                Data([UInt8(truncatingIfNeeded: slot2)]),
+                Data([UInt8(truncatingIfNeeded: slot3)]),
+                Data([UInt8(truncatingIfNeeded: slot4)]),
+                Data([UInt8(truncatingIfNeeded: slot5)]),
+                Data([UInt8(truncatingIfNeeded: slot6)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/IdpTimeDependentSegmentHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/IdpTimeDependentSegmentHistoryLog.swift
@@ -1,0 +1,71 @@
+//
+//  IdpTimeDependentSegmentHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for Personal Profile (IDP) Time Dependent Segment.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/IdpTimeDependentSegmentHistoryLog.java
+//
+import Foundation
+
+public class IdpTimeDependentSegmentHistoryLog: HistoryLog {
+    public static let typeId = 68
+
+    public let idp: Int
+    public let status: Int
+    public let segmentIndex: Int
+    public let modificationType: Int
+    public let startTime: Int
+    public let basalRate: Int
+    public let isf: Int
+    public let targetBg: UInt32
+    public let carbRatio: Int
+
+    public required init(cargo: Data) {
+        self.idp = Int(cargo[10])
+        self.status = Int(cargo[11])
+        self.segmentIndex = Int(cargo[12])
+        self.modificationType = Int(cargo[13])
+        self.startTime = Bytes.readShort(cargo, 14)
+        self.basalRate = Bytes.readShort(cargo, 16)
+        self.isf = Bytes.readShort(cargo, 18)
+        self.targetBg = Bytes.readUint32(cargo, 20)
+        self.carbRatio = Int(cargo[24])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, status: Int, segmentIndex: Int, modificationType: Int, startTime: Int, basalRate: Int, isf: Int, targetBg: UInt32, carbRatio: Int) {
+        let payload = IdpTimeDependentSegmentHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, idp: idp, status: status, segmentIndex: segmentIndex, modificationType: modificationType, startTime: startTime, basalRate: basalRate, isf: isf, targetBg: targetBg, carbRatio: carbRatio)
+        self.idp = idp
+        self.status = status
+        self.segmentIndex = segmentIndex
+        self.modificationType = modificationType
+        self.startTime = startTime
+        self.basalRate = basalRate
+        self.isf = isf
+        self.targetBg = targetBg
+        self.carbRatio = carbRatio
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, idp: Int, status: Int, segmentIndex: Int, modificationType: Int, startTime: Int, basalRate: Int, isf: Int, targetBg: UInt32, carbRatio: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: idp)]),
+                Data([UInt8(truncatingIfNeeded: status)]),
+                Data([UInt8(truncatingIfNeeded: segmentIndex)]),
+                Data([UInt8(truncatingIfNeeded: modificationType)]),
+                Bytes.firstTwoBytesLittleEndian(startTime),
+                Bytes.firstTwoBytesLittleEndian(basalRate),
+                Bytes.firstTwoBytesLittleEndian(isf),
+                Bytes.toUint32(targetBg),
+                Data([UInt8(truncatingIfNeeded: carbRatio)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ParamChangeGlobalSettingsHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ParamChangeGlobalSettingsHistoryLog.swift
@@ -1,0 +1,79 @@
+//
+//  ParamChangeGlobalSettingsHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for global settings changes.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeGlobalSettingsHistoryLog.java
+//
+import Foundation
+
+public class ParamChangeGlobalSettingsHistoryLog: HistoryLog {
+    public static let typeId = 74
+
+    public let modifiedData: Int
+    public let qbDataStatus: Int
+    public let qbActive: Int
+    public let qbDataEntryType: Int
+    public let qbIncrementUnits: Int
+    public let qbIncrementCarbs: Int
+    public let buttonVolume: Int
+    public let qbVolume: Int
+    public let bolusVolume: Int
+    public let reminderVolume: Int
+    public let alertVolume: Int
+
+    public required init(cargo: Data) {
+        self.modifiedData = Int(cargo[10])
+        self.qbDataStatus = Int(cargo[11])
+        self.qbActive = Int(cargo[12])
+        self.qbDataEntryType = Int(cargo[13])
+        self.qbIncrementUnits = Bytes.readShort(cargo, 14)
+        self.qbIncrementCarbs = Bytes.readShort(cargo, 16)
+        self.buttonVolume = Int(cargo[18])
+        self.qbVolume = Int(cargo[19])
+        self.bolusVolume = Int(cargo[20])
+        self.reminderVolume = Int(cargo[21])
+        self.alertVolume = Int(cargo[22])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, modifiedData: Int, qbDataStatus: Int, qbActive: Int, qbDataEntryType: Int, qbIncrementUnits: Int, qbIncrementCarbs: Int, buttonVolume: Int, qbVolume: Int, bolusVolume: Int, reminderVolume: Int, alertVolume: Int) {
+        let payload = ParamChangeGlobalSettingsHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, modifiedData: modifiedData, qbDataStatus: qbDataStatus, qbActive: qbActive, qbDataEntryType: qbDataEntryType, qbIncrementUnits: qbIncrementUnits, qbIncrementCarbs: qbIncrementCarbs, buttonVolume: buttonVolume, qbVolume: qbVolume, bolusVolume: bolusVolume, reminderVolume: reminderVolume, alertVolume: alertVolume)
+        self.modifiedData = modifiedData
+        self.qbDataStatus = qbDataStatus
+        self.qbActive = qbActive
+        self.qbDataEntryType = qbDataEntryType
+        self.qbIncrementUnits = qbIncrementUnits
+        self.qbIncrementCarbs = qbIncrementCarbs
+        self.buttonVolume = buttonVolume
+        self.qbVolume = qbVolume
+        self.bolusVolume = bolusVolume
+        self.reminderVolume = reminderVolume
+        self.alertVolume = alertVolume
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, modifiedData: Int, qbDataStatus: Int, qbActive: Int, qbDataEntryType: Int, qbIncrementUnits: Int, qbIncrementCarbs: Int, buttonVolume: Int, qbVolume: Int, bolusVolume: Int, reminderVolume: Int, alertVolume: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: modifiedData)]),
+                Data([UInt8(truncatingIfNeeded: qbDataStatus)]),
+                Data([UInt8(truncatingIfNeeded: qbActive)]),
+                Data([UInt8(truncatingIfNeeded: qbDataEntryType)]),
+                Bytes.firstTwoBytesLittleEndian(qbIncrementUnits),
+                Bytes.firstTwoBytesLittleEndian(qbIncrementCarbs),
+                Data([UInt8(truncatingIfNeeded: buttonVolume)]),
+                Data([UInt8(truncatingIfNeeded: qbVolume)]),
+                Data([UInt8(truncatingIfNeeded: bolusVolume)]),
+                Data([UInt8(truncatingIfNeeded: reminderVolume)]),
+                Data([UInt8(truncatingIfNeeded: alertVolume)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ParamChangePumpSettingsHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ParamChangePumpSettingsHistoryLog.swift
@@ -1,0 +1,67 @@
+//
+//  ParamChangePumpSettingsHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for pump settings parameter changes.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangePumpSettingsHistoryLog.java
+//
+import Foundation
+
+public class ParamChangePumpSettingsHistoryLog: HistoryLog {
+    public static let typeId = 73
+
+    public let modification: Int
+    public let status: Int
+    public let lowInsulinThreshold: Int
+    public let cannulaPrimeSize: Int
+    public let isFeatureLocked: Int
+    public let autoShutdownEnabled: Int
+    public let oledTimeout: Int
+    public let autoShutdownDuration: Int
+
+    public required init(cargo: Data) {
+        self.modification = Int(cargo[10])
+        self.status = Bytes.readShort(cargo, 12)
+        self.lowInsulinThreshold = Int(cargo[14])
+        self.cannulaPrimeSize = Int(cargo[15])
+        self.isFeatureLocked = Int(cargo[16])
+        self.autoShutdownEnabled = Int(cargo[17])
+        self.oledTimeout = Int(cargo[19])
+        self.autoShutdownDuration = Bytes.readShort(cargo, 20)
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, status: Int, lowInsulinThreshold: Int, cannulaPrimeSize: Int, isFeatureLocked: Int, autoShutdownEnabled: Int, oledTimeout: Int, autoShutdownDuration: Int) {
+        let payload = ParamChangePumpSettingsHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, modification: modification, status: status, lowInsulinThreshold: lowInsulinThreshold, cannulaPrimeSize: cannulaPrimeSize, isFeatureLocked: isFeatureLocked, autoShutdownEnabled: autoShutdownEnabled, oledTimeout: oledTimeout, autoShutdownDuration: autoShutdownDuration)
+        self.modification = modification
+        self.status = status
+        self.lowInsulinThreshold = lowInsulinThreshold
+        self.cannulaPrimeSize = cannulaPrimeSize
+        self.isFeatureLocked = isFeatureLocked
+        self.autoShutdownEnabled = autoShutdownEnabled
+        self.oledTimeout = oledTimeout
+        self.autoShutdownDuration = autoShutdownDuration
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, status: Int, lowInsulinThreshold: Int, cannulaPrimeSize: Int, isFeatureLocked: Int, autoShutdownEnabled: Int, oledTimeout: Int, autoShutdownDuration: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: modification)]),
+                Bytes.firstTwoBytesLittleEndian(status),
+                Data([UInt8(truncatingIfNeeded: lowInsulinThreshold)]),
+                Data([UInt8(truncatingIfNeeded: cannulaPrimeSize)]),
+                Data([UInt8(truncatingIfNeeded: isFeatureLocked)]),
+                Data([UInt8(truncatingIfNeeded: autoShutdownEnabled)]),
+                Data([UInt8(truncatingIfNeeded: oledTimeout)]),
+                Bytes.firstTwoBytesLittleEndian(autoShutdownDuration)
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ParamChangeRemSettingsHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ParamChangeRemSettingsHistoryLog.swift
@@ -1,0 +1,55 @@
+//
+//  ParamChangeRemSettingsHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for reminder parameter changes.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeRemSettingsHistoryLog.java
+//
+import Foundation
+
+public class ParamChangeRemSettingsHistoryLog: HistoryLog {
+    public static let typeId = 97
+
+    public let modification: Int
+    public let status: Int
+    public let lowBgThreshold: Int
+    public let highBgThreshold: Int
+    public let siteChangeDays: Int
+
+    public required init(cargo: Data) {
+        self.modification = Int(cargo[10])
+        self.status = Int(cargo[11])
+        self.lowBgThreshold = Bytes.readShort(cargo, 14)
+        self.highBgThreshold = Bytes.readShort(cargo, 16)
+        self.siteChangeDays = Int(cargo[18])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, status: Int, lowBgThreshold: Int, highBgThreshold: Int, siteChangeDays: Int) {
+        let payload = ParamChangeRemSettingsHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, modification: modification, status: status, lowBgThreshold: lowBgThreshold, highBgThreshold: highBgThreshold, siteChangeDays: siteChangeDays)
+        self.modification = modification
+        self.status = status
+        self.lowBgThreshold = lowBgThreshold
+        self.highBgThreshold = highBgThreshold
+        self.siteChangeDays = siteChangeDays
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, status: Int, lowBgThreshold: Int, highBgThreshold: Int, siteChangeDays: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: modification)]),
+                Data([UInt8(truncatingIfNeeded: status)]),
+                Bytes.firstTwoBytesLittleEndian(lowBgThreshold),
+                Bytes.firstTwoBytesLittleEndian(highBgThreshold),
+                Data([UInt8(truncatingIfNeeded: siteChangeDays)])
+            )
+        )
+    }
+}
+

--- a/Sources/TandemCore/Messages/HistoryLog/ParamChangeReminderHistoryLog.swift
+++ b/Sources/TandemCore/Messages/HistoryLog/ParamChangeReminderHistoryLog.swift
@@ -1,0 +1,67 @@
+//
+//  ParamChangeReminderHistoryLog.swift
+//  TandemKit
+//
+//  Created by OpenAI's ChatGPT.
+//
+//  History log entry for time-based reminder parameter changes.
+//  https://github.com/jwoglom/pumpX2/blob/main/messages/src/main/java/com/jwoglom/pumpx2/pump/messages/response/historyLog/ParamChangeReminderHistoryLog.java
+//
+import Foundation
+
+public class ParamChangeReminderHistoryLog: HistoryLog {
+    public static let typeId = 96
+
+    public let modification: Int
+    public let reminderId: Int
+    public let status: Int
+    public let enable: Int
+    public let frequencyMinutes: UInt32
+    public let startTime: Int
+    public let endTime: Int
+    public let activeDays: Int
+
+    public required init(cargo: Data) {
+        self.modification = Int(cargo[10])
+        self.reminderId = Int(cargo[11])
+        self.status = Int(cargo[12])
+        self.enable = Int(cargo[13])
+        self.frequencyMinutes = Bytes.readUint32(cargo, 14)
+        self.startTime = Bytes.readShort(cargo, 18)
+        self.endTime = Bytes.readShort(cargo, 20)
+        self.activeDays = Int(cargo[22])
+        super.init(cargo: cargo)
+    }
+
+    public init(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, reminderId: Int, status: Int, enable: Int, frequencyMinutes: UInt32, startTime: Int, endTime: Int, activeDays: Int) {
+        let payload = ParamChangeReminderHistoryLog.buildCargo(pumpTimeSec: pumpTimeSec, sequenceNum: sequenceNum, modification: modification, reminderId: reminderId, status: status, enable: enable, frequencyMinutes: frequencyMinutes, startTime: startTime, endTime: endTime, activeDays: activeDays)
+        self.modification = modification
+        self.reminderId = reminderId
+        self.status = status
+        self.enable = enable
+        self.frequencyMinutes = frequencyMinutes
+        self.startTime = startTime
+        self.endTime = endTime
+        self.activeDays = activeDays
+        super.init(cargo: payload)
+    }
+
+    public static func buildCargo(pumpTimeSec: UInt32, sequenceNum: UInt32, modification: Int, reminderId: Int, status: Int, enable: Int, frequencyMinutes: UInt32, startTime: Int, endTime: Int, activeDays: Int) -> Data {
+        return HistoryLog.fillCargo(
+            Bytes.combine(
+                Data([UInt8(typeId), 0]),
+                Bytes.toUint32(pumpTimeSec),
+                Bytes.toUint32(sequenceNum),
+                Data([UInt8(truncatingIfNeeded: modification)]),
+                Data([UInt8(truncatingIfNeeded: reminderId)]),
+                Data([UInt8(truncatingIfNeeded: status)]),
+                Data([UInt8(truncatingIfNeeded: enable)]),
+                Bytes.toUint32(frequencyMinutes),
+                Bytes.firstTwoBytesLittleEndian(startTime),
+                Bytes.firstTwoBytesLittleEndian(endTime),
+                Data([UInt8(truncatingIfNeeded: activeDays)])
+            )
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- port IDP-related history logs: action, list, bolus data, and time-dependent segment
- add parameter change history logs for global settings and reminders
- wire new history logs into parser and mark as implemented in AGENTS.md

## Testing
- `swift test` *(fails: excessive repeated warnings, build interrupted)*
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_68b3dc51d144832c99d54c4aa329969c