### PR TITLE
Add tests for missing message classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,20 +30,20 @@ Responses:
 - [x] Jpake1bResponse
    - [x] Tests for Jpake1bResponse
 - [x] Jpake2Response
-   - [ ] Tests for Jpake2Response
+   - [x] Tests for Jpake2Response
 - [x] Jpake3SessionKeyResponse
-   - [ ] Tests for Jpake3SessionKeyResponse
+   - [x] Tests for Jpake3SessionKeyResponse
 - [x] Jpake4KeyConfirmationResponse
-   - [ ] Tests for Jpake4KeyConfirmationResponse
+   - [x] Tests for Jpake4KeyConfirmationResponse
 - [x] PumpChallengeResponse
-   - [ ] Tests for PumpChallengeResponse
+   - [x] Tests for PumpChallengeResponse
 
 ### Control
 Requests:
 - [x] BolusPermissionReleaseRequest
    - [x] Tests for BolusPermissionReleaseRequest
 - [x] BolusPermissionRequest
-   - [ ] Tests for BolusPermissionRequest
+   - [x] Tests for BolusPermissionRequest
 - [x] CancelBolusRequest
    - [ ] Tests for CancelBolusRequest
 - [x] ChangeControlIQSettingsRequest

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake2ResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake2ResponseTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake2ResponseTests: XCTestCase {
+    // ./android-2024-02-29-6char2.csv
+    func test167cargoResponseSplit() {
+        MessageTester.initPumpState("test", 0)
+        let centralChallengeHash = Data(hexadecimalString: "0300174104634f4cfde021623a609c98311ae7508b41126542de029b76b1781de8f3db6e723950a8e64715c97cf44d80a6976b91ab846cdbf732bf160c1c0223f0a674a4734104732ff948fed2dbb06806502a7ae7ca0afdf1991eab79c866ff53e9d23bd4d1886f3cb55663b7979947f6a96d52511ac843b9d28b20805f263365bc50d1b93d7620bec12ade679a6b482ba5bfbe973e91dcdcd87bc3ab04090803db2945cca39e4c")!
+        let expected = Jpake2Response(appInstanceId: 0, centralChallengeHash: centralChallengeHash)
+
+        let parsed: Jpake2Response = MessageTester.test(
+            "00022502aa00000300174104634f4cfde021623a609c98311ae7508b41126542de029b76b1781de8f3db6e723950a8e64715c97cf44d80a6976b91ab846cdbf732bf160c1c0223f0a674a4734104732ff948fed2dbb06806502a7ae7ca0afdf1991eab79c866ff53e9d23bd4d1886f3cb55663b7979947f6a96d52511ac843b9d28b20805f263365bc50d1b93d7620bec12ade679a6b482ba5bfbe973e91dcdcd87bc3ab04090803db2945cca39e4c9be8",
+            2,
+            10,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        MessageTester.assertHexEquals(expected.centralChallengeHash, parsed.centralChallengeHash)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake3SessionKeyResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake3SessionKeyResponseTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake3SessionKeyResponseTests: XCTestCase {
+    // ./android-2024-02-29-6char2.csv
+    func test167cargo4responseSplit() {
+        MessageTester.initPumpState("test", 0)
+        let expected = Jpake3SessionKeyResponse(cargo: Data(hexadecimalString: "000002e91fff505adb4f0000000000000000")!)
+
+        let parsed: Jpake3SessionKeyResponse = MessageTester.test(
+            "0003270312000002e91fff505adb4f0000000000000000ba54",
+            3,
+            2,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.deviceKeyNonce, parsed.deviceKeyNonce)
+        MessageTester.assertHexEquals(expected.deviceKeyReserved, parsed.deviceKeyReserved)
+    }
+
+    // ./android-2024-02-29-6char2.csv
+    func test167cargo4responseSplitSeparated() {
+        MessageTester.initPumpState("test", 0)
+        let nonce = Data(hexadecimalString: "02e91fff505adb4f")!
+        let reserved = Data(hexadecimalString: "0000000000000000")!
+        let expected = Jpake3SessionKeyResponse(appInstanceId: 0, nonce: nonce, reserved: reserved)
+
+        let parsed: Jpake3SessionKeyResponse = MessageTester.test(
+            "0003270312000002e91fff505adb4f0000000000000000ba54",
+            3,
+            2,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.deviceKeyNonce, parsed.deviceKeyNonce)
+        MessageTester.assertHexEquals(expected.deviceKeyReserved, parsed.deviceKeyReserved)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/Jpake4KeyConfirmationResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/Jpake4KeyConfirmationResponseTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import TandemCore
+
+final class Jpake4KeyConfirmationResponseTests: XCTestCase {
+    // ./android-2024-02-29-6char2.csv
+    func test167cargo5responseSplit() {
+        MessageTester.initPumpState("test", 0)
+        let nonce = Data(hexadecimalString: "e3fd32509dfacf47")!
+        let reserved = Data(hexadecimalString: "0000000000000000")!
+        let hashDigest = Data(hexadecimalString: "d0410856c350ce6b9756e03810c6f99a4a0743160a1fdb0973db2f90bdc9a96a")!
+        let expected = Jpake4KeyConfirmationResponse(appInstanceId: 0, nonce: nonce, reserved: reserved, hashDigest: hashDigest)
+
+        let parsed: Jpake4KeyConfirmationResponse = MessageTester.test(
+            "00042904320000e3fd32509dfacf470000000000000000d0410856c350ce6b9756e03810c6f99a4a0743160a1fdb0973db2f90bdc9a96ad742",
+            4,
+            4,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        MessageTester.assertHexEquals(expected.nonce, parsed.nonce)
+        MessageTester.assertHexEquals(expected.reserved, parsed.reserved)
+        MessageTester.assertHexEquals(expected.hashDigest, parsed.hashDigest)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Authentication/PumpChallengeResponseTests.swift
+++ b/Tests/TandemCoreTests/Messages/Authentication/PumpChallengeResponseTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import TandemCore
+
+final class PumpChallengeResponseTests: XCTestCase {
+    func testTconnectAppChallengeResponseMessageSuccess_legacyAuth() {
+        MessageTester.initPumpState("test", 0)
+        let expected = PumpChallengeResponse(appInstanceId: 1, success: true)
+
+        let parsed: PumpChallengeResponse = MessageTester.test(
+            "0001130103010001e8cc",
+            1,
+            1,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        XCTAssertEqual(expected.success, parsed.success)
+    }
+
+    func testTconnectAppChallengeResponseMessageFailure_legacyAuth() {
+        MessageTester.initPumpState("test", 0)
+        let expected = PumpChallengeResponse(appInstanceId: 1, success: false)
+
+        let parsed: PumpChallengeResponse = MessageTester.test(
+            "0001130103010000c9dc",
+            1,
+            1,
+            .AUTHORIZATION_CHARACTERISTICS,
+            expected
+        )
+
+        XCTAssertEqual(expected.appInstanceId, parsed.appInstanceId)
+        XCTAssertEqual(expected.success, parsed.success)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/BolusPermissionRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/BolusPermissionRequestTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import TandemCore
+
+final class BolusPermissionRequestTests: XCTestCase {
+    func testBolusPermissionRequest_unknown1() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461457713)
+        let expected = BolusPermissionRequest()
+
+        let messages = [
+            "0134a234181d47811bc64bcd072fc978e4842046",
+            "003426b62ba72612b4f04978ac"
+        ]
+        let parsed: BolusPermissionRequest = MessageTester.test(
+            messages[0],
+            52,
+            2,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            messages[1]
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}


### PR DESCRIPTION
## Summary
- add response tests for JPAKE rounds 2-4 and pump challenge
- add control test for bolus permission request
- mark covered message tests in AGENTS.md

## Testing
- `swift test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b3dc798440832c945f93190d06a0cb