### PR TITLE
Handle qualifying event suggested messages

### DIFF
--- a/Sources/TandemBLE/Bluetooth/BluetoothManager.swift
+++ b/Sources/TandemBLE/Bluetooth/BluetoothManager.swift
@@ -10,7 +10,9 @@ import CoreBluetooth
 import Foundation
 import LoopKit
 import TandemCore
+#if canImport(os)
 import os
+#endif
 
 
 protocol BluetoothManagerDelegate: AnyObject {
@@ -60,7 +62,17 @@ class BluetoothManager: NSObject, @unchecked Sendable {
 
     weak var delegate: BluetoothManagerDelegate?
 
-    private let log = OSLog(subsystem: "BluetoothManager", category: "TandemKit")
+    #if canImport(os)
+    private let log = Logger(subsystem: "BluetoothManager", category: "TandemKit")
+    #else
+    private struct DummyLogger {
+        func debug(_ message: String, _ args: CVarArg...) {}
+        func `default`(_ message: String, _ args: CVarArg...) {}
+        func info(_ message: String, _ args: CVarArg...) {}
+        func error(_ message: String, _ args: CVarArg...) {}
+    }
+    private let log = DummyLogger()
+    #endif
 
     private let concurrentReconnectSemaphore = DispatchSemaphore(value: 1)
 

--- a/Sources/TandemCore/CharacteristicUUID.swift
+++ b/Sources/TandemCore/CharacteristicUUID.swift
@@ -31,5 +31,11 @@ public let AllPumpCharacteristicUUIDs: [CharacteristicUUID] = [
 ]
 
 public extension CharacteristicUUID {
-    var cbUUID: CBUUID { CBUUID(string: rawValue) }
+    var cbUUID: CBUUID {
+#if os(Linux)
+        return CBUUID(uuidString: rawValue)
+#else
+        return CBUUID(string: rawValue)
+#endif
+    }
 }

--- a/Sources/TandemCore/ServiceUUID.swift
+++ b/Sources/TandemCore/ServiceUUID.swift
@@ -29,5 +29,11 @@ public let AllServiceUUIDs: [ServiceUUID] = [
 ]
 
 public extension ServiceUUID {
-    var cbUUID: CBUUID { CBUUID(string: rawValue) }
+    var cbUUID: CBUUID {
+#if os(Linux)
+        return CBUUID(uuidString: rawValue)
+#else
+        return CBUUID(string: rawValue)
+#endif
+    }
 }

--- a/Tests/TandemCoreTests/Messages/QualifyingEvent/QualifyingEventTests.swift
+++ b/Tests/TandemCoreTests/Messages/QualifyingEvent/QualifyingEventTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import TandemCore
+
+final class QualifyingEventTests: XCTestCase {
+    func testFromBitmaskMultiple() {
+        let mask: UInt32 = QualifyingEvent.alert.id | QualifyingEvent.alarm.id | QualifyingEvent.bolusPermissionRevoked.id
+        let events = QualifyingEvent.fromBitmask(mask)
+        XCTAssertTrue(events.contains(.alert))
+        XCTAssertTrue(events.contains(.alarm))
+        XCTAssertTrue(events.contains(.bolusPermissionRevoked))
+        XCTAssertEqual(events.count, 3)
+    }
+
+    @MainActor
+    func testSuggestedHandlersAlert() {
+        let handlers = QualifyingEvent.alert.suggestedHandlers
+        XCTAssertEqual(handlers.count, 1)
+        let msg = handlers[0]()
+        XCTAssertTrue(msg is AlertStatusRequest)
+    }
+
+    @MainActor
+    func testGroupSuggestedHandlersDeduplicates() {
+        let events: Set<QualifyingEvent> = [.pumpSuspend, .pumpResume]
+        let messages = QualifyingEvent.groupSuggestedHandlers(events)
+        // InsulinStatusRequest should only appear once
+        let opcodes = messages.map { type(of: $0).props.opCode }
+        XCTAssertEqual(opcodes.count, Set(opcodes).count)
+        XCTAssertTrue(opcodes.contains(InsulinStatusRequest.props.opCode))
+    }
+}


### PR DESCRIPTION
## Summary
- implement suggested handler mapping for all pump qualifying events
- add cross-platform Bluetooth UUID helpers and conditional logging
- test qualifying event bitmask parsing and deduped handler grouping

## Testing
- `swift test` *(fails: no such module 'os')*

------
https://chatgpt.com/codex/tasks/task_e_68b3df55caec832c83848aeb02a539fb