### PR TITLE
Add tests for control mode requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,15 +55,15 @@ Requests:
 - [x] DeleteIDPRequest
    - [x] Tests for DeleteIDPRequest
 - [x] DisconnectPumpRequest
-   - [ ] Tests for DisconnectPumpRequest
+   - [x] Tests for DisconnectPumpRequest
 - [x] DismissNotificationRequest
-   - [ ] Tests for DismissNotificationRequest
+   - [x] Tests for DismissNotificationRequest
 - [x] EnterChangeCartridgeModeRequest
-   - [ ] Tests for EnterChangeCartridgeModeRequest
+   - [x] Tests for EnterChangeCartridgeModeRequest
 - [x] EnterFillTubingModeRequest
-   - [ ] Tests for EnterFillTubingModeRequest
+   - [x] Tests for EnterFillTubingModeRequest
 - [x] ExitChangeCartridgeModeRequest
-   - [ ] Tests for ExitChangeCartridgeModeRequest
+   - [x] Tests for ExitChangeCartridgeModeRequest
 - [x] ExitFillTubingModeRequest
    - [ ] Tests for ExitFillTubingModeRequest
 - [x] FillCannulaRequest

--- a/Tests/TandemCoreTests/Messages/Control/DisconnectPumpRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/DisconnectPumpRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import TandemCore
+
+final class DisconnectPumpRequestTests: XCTestCase {
+    func testDisconnectPumpRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = DisconnectPumpRequest()
+        let parsed: DisconnectPumpRequest = MessageTester.test(
+            "01debede18da38f31f38413194c36c036e110c25",
+            -34,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00deff81b3f10f7af28dcfb8fc"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/DismissNotificationRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/DismissNotificationRequestTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import TandemCore
+
+final class DismissNotificationRequestTests: XCTestCase {
+    func testDismissNotificationRequest_SiteChangeNotification() {
+        MessageTester.initPumpState("", 0)
+        let expected = DismissNotificationRequest(cargo: Data([2,0,0,0,0,0]))
+        let parsed: DismissNotificationRequest = MessageTester.test(
+            "011eb81e1e02000000000091eef21fb2f51e9b10",
+            30,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "001e1923326c7764e514a7cd6e702210fbe0f0"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(UInt32(ReminderStatusResponse.ReminderType.SITE_CHANGE_REMINDER.rawValue), parsed.notificationId)
+        XCTAssertEqual(.reminder, parsed.notificationType)
+    }
+
+    func testDismissNotificationRequest_alert_CGM_GRAPH_REMOVED() {
+        MessageTester.initPumpState("", 0)
+        let expected = DismissNotificationRequest(cargo: Data([25,0,0,0,1,0]))
+        let parsed: DismissNotificationRequest = MessageTester.test(
+            "01ddb8dd1e1900000001001b92f41f4ebdd42d94",
+            -35,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00dd71575252fcc1476112db4196041031cf27"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(UInt32(AlertStatusResponse.AlertResponseType.CGM_GRAPH_REMOVED.rawValue), parsed.notificationId)
+        XCTAssertEqual(.alert, parsed.notificationType)
+    }
+
+    func testDismissNotificationRequest_alert_INVALID_TRANSMITTER_ID() {
+        MessageTester.initPumpState("", 0)
+        let expected = DismissNotificationRequest(cargo: Data([29,0,0,0,1,0]))
+        let parsed: DismissNotificationRequest = MessageTester.test(
+            "0112b8121e1d00000001008190fd1fd4f0eef6a2",
+            18,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "0012398a829fd5358e41f168f0b82619ad9976"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(UInt32(AlertStatusResponse.AlertResponseType.INVALID_TRANSMITTER_ID.rawValue), parsed.notificationId)
+        XCTAssertEqual(.alert, parsed.notificationType)
+    }
+
+    func testDismissNotificationRequest_g6CgmSensorFailed() {
+        MessageTester.initPumpState("", 0)
+        let expected = DismissNotificationRequest(cargo: Data([11,0,0,0,3,0]))
+        let parsed: DismissNotificationRequest = MessageTester.test(
+            "01e9b8e91e0b0000000300de6e392075306d24bb",
+            -23,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00e92094d6d88830447aa4c9d10af3196a91a1"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(UInt32(CGMAlertStatusResponse.CGMAlert.SENSOR_FAILED_CGM_ALERT.rawValue), parsed.notificationId)
+        XCTAssertEqual(.cgmAlert, parsed.notificationType)
+    }
+
+    func testDismissNotificationRequest_pumpResetAlarm() {
+        MessageTester.initPumpState("", 0)
+        let expected = DismissNotificationRequest(cargo: Data([3,0,0,0,2,0]))
+        let parsed: DismissNotificationRequest = MessageTester.test(
+            "01a6b8a61e03000000020058e93920faf75ae477",
+            -90,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00a674346fb57c95916f8fde8e2e79f605dee3"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(UInt32(AlarmStatusResponse.AlarmResponseType.PUMP_RESET_ALARM.rawValue), parsed.notificationId)
+        XCTAssertEqual(.alarm, parsed.notificationType)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/EnterChangeCartridgeModeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/EnterChangeCartridgeModeRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import TandemCore
+
+final class EnterChangeCartridgeModeRequestTests: XCTestCase {
+    func testEnterChangeCartridgeModeRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = EnterChangeCartridgeModeRequest()
+        let parsed: EnterChangeCartridgeModeRequest = MessageTester.test(
+            "01369036181d142820db51e5fa626a7df87fc2cf",
+            54,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "003621097bdd2395333e5d7d63"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/EnterFillTubingModeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/EnterFillTubingModeRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import TandemCore
+
+final class EnterFillTubingModeRequestTests: XCTestCase {
+    func testEnterFillTubingModeRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = EnterFillTubingModeRequest()
+        let parsed: EnterFillTubingModeRequest = MessageTester.test(
+            "017a947a1851eaee1f5595738c382cc5dc5552a2",
+            122,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "007a4aa8482c322b5fd69805e8"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/ExitChangeCartridgeModeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/ExitChangeCartridgeModeRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import TandemCore
+
+final class ExitChangeCartridgeModeRequestTests: XCTestCase {
+    func testExitChangeCartridgeModeRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = ExitChangeCartridgeModeRequest()
+        let parsed: ExitChangeCartridgeModeRequest = MessageTester.test(
+            "0189928918e40e4120bd5bce64b42a9df62d8cae",
+            -119,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "0089e8d1e8325cc6cacddc7790"
+        )
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}


### PR DESCRIPTION
## Summary
- add DisconnectPumpRequestTests
- add DismissNotificationRequestTests
- add EnterChangeCartridgeModeRequestTests
- add EnterFillTubingModeRequestTests
- add ExitChangeCartridgeModeRequestTests

## Testing
- `swift build --target TandemCoreTests`
- `swift test 2>&1 | tail -n 20` *(fails: no such module 'os')*

------
https://chatgpt.com/codex/tasks/task_e_68b7c7747300832ca9d5983681657b4a