### PR TITLE
Port PumpX2 control request tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,15 +65,15 @@ Requests:
 - [x] ExitChangeCartridgeModeRequest
    - [x] Tests for ExitChangeCartridgeModeRequest
 - [x] ExitFillTubingModeRequest
-   - [ ] Tests for ExitFillTubingModeRequest
+   - [x] Tests for ExitFillTubingModeRequest
 - [x] FillCannulaRequest
-   - [ ] Tests for FillCannulaRequest
+   - [x] Tests for FillCannulaRequest
 - [x] InitiateBolusRequest
-   - [ ] Tests for InitiateBolusRequest
+   - [x] Tests for InitiateBolusRequest
 - [x] PlaySoundRequest
-   - [ ] Tests for PlaySoundRequest
+   - [x] Tests for PlaySoundRequest
 - [x] RemoteBgEntryRequest
-   - [ ] Tests for RemoteBgEntryRequest
+   - [x] Tests for RemoteBgEntryRequest
 - [x] RemoteCarbEntryRequest
    - [ ] Tests for RemoteCarbEntryRequest
 - [x] RenameIDPRequest

--- a/Tests/TandemCoreTests/Messages/Control/ExitFillTubingModeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/ExitFillTubingModeRequestTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TandemCore
+
+final class ExitFillTubingModeRequestTests: XCTestCase {
+    func testExitFillTubingModeRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = ExitFillTubingModeRequest()
+
+        let parsed: ExitFillTubingModeRequest = MessageTester.test(
+            "01919691181b0f4120ad6869443532522e06f02a",
+            -111,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "0091687757e745d1f795a3295f"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/FillCannulaRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/FillCannulaRequestTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TandemCore
+
+final class FillCannulaRequestTests: XCTestCase {
+    func testFillCannulaRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = FillCannulaRequest(primeSizeMilliUnits: 300)
+
+        let parsed: FillCannulaRequest = MessageTester.test(
+            "016d986d1a2c010f152820b9273d0fb99c1241f1",
+            109,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "006db9da764426a0aa99bb708571f4"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/InitiateBolusRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/InitiateBolusRequestTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import TandemCore
+
+final class InitiateBolusRequestTests: XCTestCase {
+    func testInitiateBolusRequest_ID10650_1u() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461510642)
+        let expected = InitiateBolusRequest(
+            totalVolume: 1000,
+            bolusID: 10650,
+            bolusTypeBitmask: 8,
+            foodVolume: 0,
+            correctionVolume: 0,
+            bolusCarbs: 0,
+            bolusBG: 0,
+            bolusIOB: 0
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "03399e393de80300009a29000008000000000000",
+            57,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "0239000000000000000000000000000000000000",
+            "013900000000f217821b68f94cebe6717a5d1551",
+            "003927147fec9ad979926aaccd74"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(1000, Int(parsed.totalVolume))
+        XCTAssertEqual(10650, parsed.bolusID)
+        XCTAssertEqual(8, parsed.bolusTypeBitmask)
+        XCTAssertEqual(Set([BolusType.food2]), parsed.bolusTypes)
+        XCTAssertEqual(0, Int(parsed.foodVolume))
+        XCTAssertEqual(0, Int(parsed.correctionVolume))
+        XCTAssertEqual(0, parsed.bolusCarbs)
+        XCTAssertEqual(0, parsed.bolusBG)
+        XCTAssertEqual(0, Int(parsed.bolusIOB))
+    }
+
+    func testInitiateBolusRequest_ID10652_013u_13g_carbs_142mgdl() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461589180)
+        let expected = InitiateBolusRequest(
+            totalVolume: 130,
+            bolusID: 10652,
+            bolusTypeBitmask: 1,
+            foodVolume: 130,
+            correctionVolume: 0,
+            bolusCarbs: 13,
+            bolusBG: 142,
+            bolusIOB: 0
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "033e9e3e3d820000009c29000001820000000000",
+            62,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "023e00000d008e00000000000000000000000000",
+            "013e00000000bc4a831b9cbf19ffb856288a8afa",
+            "003e8f24a463e00cf3bbe5d305dd"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(130, Int(parsed.totalVolume))
+        XCTAssertEqual(10652, parsed.bolusID)
+        XCTAssertEqual(1, parsed.bolusTypeBitmask)
+        XCTAssertEqual(Set([BolusType.food1]), parsed.bolusTypes)
+        XCTAssertEqual(130, Int(parsed.foodVolume))
+        XCTAssertEqual(0, Int(parsed.correctionVolume))
+        XCTAssertEqual(13, parsed.bolusCarbs)
+        XCTAssertEqual(142, parsed.bolusBG)
+        XCTAssertEqual(0, Int(parsed.bolusIOB))
+    }
+
+    func testInitiateBolusRequest_ID10653_011u_11g_carbs_161mgdl_013u_iob() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461589420)
+        let expected = InitiateBolusRequest(
+            totalVolume: 110,
+            bolusID: 10653,
+            bolusTypeBitmask: 1,
+            foodVolume: 110,
+            correctionVolume: 0,
+            bolusCarbs: 11,
+            bolusBG: 161,
+            bolusIOB: 130
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "03399e393d6e0000009d290000016e0000000000",
+            57,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "023900000b00a100820000000000000000000000",
+            "013900000000ac4b831b7a0b7cfc14a30b9c3995",
+            "0039dc8bbbdfa2ce2ce995725407"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(110, Int(parsed.totalVolume))
+        XCTAssertEqual(10653, parsed.bolusID)
+        XCTAssertEqual(1, parsed.bolusTypeBitmask)
+        XCTAssertEqual(Set([BolusType.food1]), parsed.bolusTypes)
+        XCTAssertEqual(110, Int(parsed.foodVolume))
+        XCTAssertEqual(0, Int(parsed.correctionVolume))
+        XCTAssertEqual(11, parsed.bolusCarbs)
+        XCTAssertEqual(161, parsed.bolusBG)
+        XCTAssertEqual(130, Int(parsed.bolusIOB))
+    }
+
+    func testInitiateBolusRequest_ID10677() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710145)
+        let expected = InitiateBolusRequest(
+            totalVolume: 770,
+            bolusID: 10677,
+            bolusTypeBitmask: 3,
+            foodVolume: 50,
+            correctionVolume: 720,
+            bolusCarbs: 5,
+            bolusBG: 185,
+            bolusIOB: 0
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "03ab9eab3d02030000b52900000332000000d002",
+            -85,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "02ab00000500b900000000000000000000000000",
+            "01ab000000004123851bd5302d47de4038f56320",
+            "00abce9113be8ce2a1e1b82126c5"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testInitiateBolusRequest_ID10678() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710202)
+        let expected = InitiateBolusRequest(
+            totalVolume: 760,
+            bolusID: 10678,
+            bolusTypeBitmask: 3,
+            foodVolume: 30,
+            correctionVolume: 730,
+            bolusCarbs: 3,
+            bolusBG: 186,
+            bolusIOB: 0
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "03d09ed03df8020000b6290000031e000000da02",
+            -48,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "02d000000300ba00000000000000000000000000",
+            "01d0000000007a23851bcd0708af0ac0a24f2ee7",
+            "00d0fa056febc1e4710541765047"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testInitiateBolusRequest_Mobi_Extended() {
+        MessageTester.initPumpState("", 1905413)
+        let expected = InitiateBolusRequest(
+            totalVolume: 250,
+            bolusID: 501,
+            bolusTypeBitmask: 12,
+            foodVolume: 0,
+            correctionVolume: 0,
+            bolusCarbs: 0,
+            bolusBG: 170,
+            bolusIOB: 2810,
+            extendedVolume: 250,
+            extendedSeconds: 7200,
+            extended3: 0
+        )
+
+        let parsed: InitiateBolusRequest = MessageTester.test(
+            "030d9e0d3dfa000000f50100000c000000000000",
+            13,
+            3,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "020d00000000aa00fa0a0000fa000000201c0000",
+            "010d00000000b4968b1eae36a1f4be8a1069db07",
+            "000d5f7074e1705b443ff533986f"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(250, Int(parsed.extendedVolume))
+        XCTAssertEqual(7200, Int(parsed.extendedSeconds))
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/PlaySoundRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/PlaySoundRequestTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TandemCore
+
+final class PlaySoundRequestTests: XCTestCase {
+    func testPlaySoundRequest() {
+        MessageTester.initPumpState("", 0)
+        let expected = PlaySoundRequest()
+
+        let parsed: PlaySoundRequest = MessageTester.test(
+            "01cef4ce182337f31f36da5eea5ed250773df9b0",
+            -50,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00ce91daca790983cb56d5fff1"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/RemoteBgEntryRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/RemoteBgEntryRequestTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import TandemCore
+
+final class RemoteBgEntryRequestTests: XCTestCase {
+    func testRemoteBgEntryRequest_ID10676() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710145)
+        let expected = RemoteBgEntryRequest(bg: 180, useForCgmCalibration: false, isAutopopBg: true, pumpTime: 1200173, bolusId: 10676)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "023bb63b23b4000000012d501200b4290023851b",
+            59,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "013b1f62ef2f006c8a8ea7aeb9203fa4b7eaebd2",
+            "003bc0b6800c"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteBgEntryRequest_ID10677() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710145)
+        let expected = RemoteBgEntryRequest(bg: 185, useForCgmCalibration: false, isAutopopBg: true, pumpTime: 1200239, bolusId: 10677)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "02a9b6a923b9000000016f501200b5294123851b",
+            -87,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01a93ade55510ac65b57f647a1899c0a6e4e94bc",
+            "00a9d8306d38"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteBgEntryRequest_ID10678() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710202)
+        let expected = RemoteBgEntryRequest(bg: 186, useForCgmCalibration: false, isAutopopBg: true, pumpTime: 1200239, bolusId: 10678)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "02ceb6ce23ba000000016f501200b6297a23851b",
+            -50,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01ceb50b6d51ca170c5ecf018b37a14a4a05c412",
+            "00ceda1ff8b1"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteBgEntryRequest_ID10652() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461589158)
+        let expected = RemoteBgEntryRequest(bg: 142, useForCgmCalibration: false, isAutopopBg: true, pumpTime: 1079274, bolusId: 10652)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "023cb63c238e00000001ea7710009c29bc4a831b",
+            60,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "013c1d2edd239e1a8499a6686078565ad1b8acdc",
+            "003ca71a3107"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteBgEntryRequest_G7Calibrate_169mgdl() {
+        MessageTester.initPumpState("", 0)
+        let expected = RemoteBgEntryRequest(bg: 169, useForCgmCalibration: true, isAutopopBg: true, pumpTime: 2887044, bolusId: 0)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "02d6b6d623a900010001840d2c00000052cf5a20",
+            -42,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01d6e4b43557b2ab113cb54266a2d1616c1972f8",
+            "00d66e6d6786"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteBgEntryRequest_G7Calibrate_170mgdl() {
+        MessageTester.initPumpState("", 0)
+        let expected = RemoteBgEntryRequest(bg: 170, useForCgmCalibration: true, isAutopopBg: true, pumpTime: 2887044, bolusId: 0)
+
+        let parsed: RemoteBgEntryRequest = MessageTester.test(
+            "02e1b6e123aa00010001840d2c00000082cf5a20",
+            -31,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01e10d94486401b99108897a2c3fdb9c2ec6be15",
+            "00e1663cfd1a"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}


### PR DESCRIPTION
## Summary
- add XCTest coverage for ExitFillTubingModeRequest
- add FillCannulaRequest tests
- port extensive InitiateBolusRequest scenarios
- cover PlaySoundRequest and RemoteBgEntryRequest
- mark test coverage in AGENTS.md

## Testing
- `swift build --target TandemCore`
- `swift test` *(fails: no such module 'os')*

------
https://chatgpt.com/codex/tasks/task_e_68b8dbac83f8832cbae87060308a7946