### PR TITLE
Add control request tests for carb entry, IDP management, and Dexcom pairing

### DIFF
--- a/Sources/TandemCore/Common/Bytes.swift
+++ b/Sources/TandemCore/Common/Bytes.swift
@@ -161,7 +161,7 @@ public struct Bytes {
         var encoded = Data(input.utf8)
         // Pad with null bytes up to the requested length
         while encoded.count < length {
-            encoded.append(0)
+            encoded.append(UInt8(0))
         }
         return encoded
     }

--- a/Tests/TandemCoreTests/Messages/Control/RemoteCarbEntryRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/RemoteCarbEntryRequestTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import TandemCore
+
+final class RemoteCarbEntryRequestTests: XCTestCase {
+    func testOpcodeNegative14Request_ID10677() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710145)
+        let expected = RemoteCarbEntryRequest(carbs: 5, pumpTime: 1200239, bolusId: 10677)
+
+        let parsed: RemoteCarbEntryRequest = MessageTester.test(
+            "02aaf2aa210500016f501200b5294123851bf324",
+            -86,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01aaa4f96f10fe37167c6d90d2802fda729c1e0e",
+            "00aa0288"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testOpcodeNegative14Request_ID10678() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461710202)
+        let expected = RemoteCarbEntryRequest(carbs: 3, pumpTime: 1200239, bolusId: 10678)
+
+        let parsed: RemoteCarbEntryRequest = MessageTester.test(
+            "02cff2cf210300016f501200b6297a23851bc88f",
+            -49,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01cfdcc573801e4a91567fe0219a9275211f7f17",
+            "00cfa162"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testRemoteCarbEntryRequest_ID10653_011u_11g_carbs_161mgdl_013u_iob() {
+        MessageTester.initPumpState("6VeDeRAL5DCigGw2", 461589420)
+        let expected = RemoteCarbEntryRequest(carbs: 11, pumpTime: 1079469, bolusId: 10653)
+
+        let parsed: RemoteCarbEntryRequest = MessageTester.test(
+            "0238f238210b0001ad7810009d29ac4b831b5e16",
+            56,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "013890d5f066c547ed4e3e883476f805abc0ddf9",
+            "00383346"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/RenameIDPRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/RenameIDPRequestTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import TandemCore
+
+final class RenameIDPRequestTests: XCTestCase {
+    func testRenameIDPRequest() {
+        MessageTester.initPumpState("IGNORE_HMAC_SIGNATURE_EXCEPTION", 1)
+        let expected = RenameIDPRequest(idpId: 1, profileName: "testprofil2")
+
+        let parsed: RenameIDPRequest = MessageTester.test(
+            "02d6a8d62b01017465737470726f66696c320000",
+            -42,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01d600000000e4483e2065ee618e7bd6a980f0a6",
+            "00d60656ac383c1140bccf5a20be"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/ResumePumpingRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/ResumePumpingRequestTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TandemCore
+
+final class ResumePumpingRequestTests: XCTestCase {
+    func testResumePumpingRequest() {
+        MessageTester.initPumpState("IGNORE_HMAC_SIGNATURE_EXCEPTION", 0)
+        let expected = ResumePumpingRequest()
+
+        let parsed: ResumePumpingRequest = MessageTester.test(
+            "013d9a3d1808eaee1ff9e90b186d391c9892ca8f",
+            61,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "003d7bc20e2a68cc7bc5c6fcce"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/SetActiveIDPRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/SetActiveIDPRequestTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import TandemCore
+
+final class SetActiveIDPRequestTests: XCTestCase {
+    func testSetActiveIDPRequest_profileWithId1() {
+        MessageTester.initPumpState("IGNORE_HMAC_SIGNATURE_EXCEPTION", 1)
+        let expected = SetActiveIDPRequest(idpId: 1)
+
+        let parsed: SetActiveIDPRequest = MessageTester.test(
+            "0119ec191a010165493e2009a33736acb3713492",
+            25,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00199d7598653853bd78abd443ec3b"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+
+    func testSetActiveIDPRequest_profileWithId0() {
+        MessageTester.initPumpState("IGNORE_HMAC_SIGNATURE_EXCEPTION", 1)
+        let expected = SetActiveIDPRequest(idpId: 0)
+
+        let parsed: SetActiveIDPRequest = MessageTester.test(
+            "0124ec241a00017c493e2027b0811608d99b2431",
+            36,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "00249dec87124ebe4216766ea86133"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+    }
+}

--- a/Tests/TandemCoreTests/Messages/Control/SetDexcomG7PairingCodeRequestTests.swift
+++ b/Tests/TandemCoreTests/Messages/Control/SetDexcomG7PairingCodeRequestTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import TandemCore
+
+final class SetDexcomG7PairingCodeRequestTests: XCTestCase {
+    func testSetG7PairingCodeRequest_code3546() {
+        MessageTester.initPumpState("IGNORE_HMAC_SIGNATURE_EXCEPTION", 1)
+        let expected = SetDexcomG7PairingCodeRequest(pairingCode: 3546)
+
+        let parsed: SetDexcomG7PairingCodeRequest = MessageTester.test(
+            "02f9fcf920da0d000000000000e68cfd1fc0e13b",
+            -7,
+            1,
+            .CONTROL_CHARACTERISTICS,
+            expected,
+            "01f9ff4ae4968d2f256e803caa2487aeea5e8e20",
+            "00f9f8"
+        )
+
+        MessageTester.assertHexEquals(expected.cargo, parsed.cargo)
+        XCTAssertEqual(3546, parsed.pairingCode)
+    }
+}


### PR DESCRIPTION
## Summary
- migrate the PumpX2 RemoteCarbEntryRequest, RenameIDPRequest, ResumePumpingRequest, SetActiveIDPRequest, and SetDexcomG7PairingCodeRequest test cases into TandemCore
- ensure `Bytes.writeString` pads strings byte-by-byte so request cargos align with the PumpX2 expectations

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cda4c4535c832c9e8f5ef3d9b8368d